### PR TITLE
nrf5/modules/ubluepy: Fixing compilation bug of wrong variable name w…

### DIFF
--- a/nrf5/modules/ubluepy/ubluepy_peripheral.c
+++ b/nrf5/modules/ubluepy/ubluepy_peripheral.c
@@ -372,7 +372,7 @@ STATIC mp_obj_t peripheral_connect(mp_obj_t self_in, mp_obj_t dev_addr) {
         ;
     }
 
-    ble_drv_gattc_event_handler_set(MP_OBJ_FROM_PTR(s), gattc_event_handler);
+    ble_drv_gattc_event_handler_set(MP_OBJ_FROM_PTR(self), gattc_event_handler);
 
     bool retval = ble_drv_discover_services(self, self->conn_handle, disc_add_service);
     if (retval != true) {


### PR DESCRIPTION
…hen registering gattc event handler in ublupy peripheral connect function (central mode).