### PR TITLE
nrf5/modules/ubluepy: Making peripheral conn_handle volatile. Upon co…

### DIFF
--- a/nrf5/modules/ubluepy/modubluepy.h
+++ b/nrf5/modules/ubluepy/modubluepy.h
@@ -116,7 +116,7 @@ typedef struct _ubluepy_uuid_obj_t {
 typedef struct _ubluepy_peripheral_obj_t {
     mp_obj_base_t       base;
     ubluepy_role_type_t role;
-    uint16_t            conn_handle;
+    volatile uint16_t   conn_handle;
     mp_obj_t            delegate;
     mp_obj_t            notif_handler;
     mp_obj_t            conn_handler;


### PR DESCRIPTION
…nnection event, the variable is accessed in thread mode. However, the main-loop is blocking on conn_handle != 0xFFFF. If this is not volatile, optimized code will not exit the loop.