### PR TITLE
nrf5/drivers/bluetooth: As callback functions are in most usecases ar…

### DIFF
--- a/nrf5/drivers/bluetooth/ble_drv.c
+++ b/nrf5/drivers/bluetooth/ble_drv.c
@@ -78,11 +78,11 @@ static mp_obj_t mp_gatts_observer;
 static volatile bool m_primary_service_found;
 static volatile bool m_characteristic_found;
 
-static ble_drv_adv_evt_callback_t          adv_event_handler;
-static ble_drv_gattc_evt_callback_t        gattc_event_handler;
-static ble_drv_disc_add_service_callback_t disc_add_service_handler;
-static ble_drv_disc_add_char_callback_t    disc_add_char_handler;
-static ble_drv_gattc_char_data_callback_t  gattc_char_data_handle;
+static volatile ble_drv_adv_evt_callback_t          adv_event_handler;
+static volatile ble_drv_gattc_evt_callback_t        gattc_event_handler;
+static volatile ble_drv_disc_add_service_callback_t disc_add_service_handler;
+static volatile ble_drv_disc_add_char_callback_t    disc_add_char_handler;
+static volatile ble_drv_gattc_char_data_callback_t  gattc_char_data_handle;
 
 static mp_obj_t mp_adv_observer;
 static mp_obj_t mp_gattc_observer;


### PR DESCRIPTION
…e set to NULL upon last event to get public API function out of blocking mode, these function pointers has to be set as volatile, as they are updated to NULL in interrupt context, but read in blocking main-thread.