### PR TITLE
nrf5/hal/irq: Adding include of nrf_nvic.h if s132 bluetooth stack is…

### DIFF
--- a/nrf5/hal/hal_irq.h
+++ b/nrf5/hal/hal_irq.h
@@ -32,7 +32,11 @@
 #include "nrf.h"
 
 #if BLUETOOTH_SD
-#include "nrf_sdm.h"
+#if NRF51
+  #include "nrf_sdm.h"
+#elif NRF52
+  #include "nrf_nvic.h"
+#endif
 #endif
 
 static inline void hal_irq_clear(uint32_t irq_num) {


### PR DESCRIPTION
… used to resolve IRQ function wrappers on newer bluetooth stacks.