### PR TITLE
nrf5/drivers/bluetooth: Enable ubluepy central by default if running …

### DIFF
--- a/nrf5/bluetooth_conf.h
+++ b/nrf5/bluetooth_conf.h
@@ -18,7 +18,7 @@
 #define BLUETOOTH_WEBBLUETOOTH_REPL     (0)
 #define MICROPY_PY_UBLUEPY              (1)
 #define MICROPY_PY_UBLUEPY_PERIPHERAL   (1)
-#define MICROPY_PY_UBLUEPY_CENTRAL      (0)
+#define MICROPY_PY_UBLUEPY_CENTRAL      (1)
 
 #else
 #error "SD not supported"


### PR DESCRIPTION
…nrf52/s132 bluetooth stack. Maturity of the module is pretty OK now.