### PR TITLE
nrf5/boards/feather52: Add SERIAL makeflag if dfu-flash target is used.

### DIFF
--- a/nrf5/boards/feather52/mpconfigboard.mk
+++ b/nrf5/boards/feather52/mpconfigboard.mk
@@ -7,10 +7,19 @@ LD_FILE = boards/feather52/custom_nrf52832_dfu_app.ld
 
 NRF_DEFINES += -DNRF52832_XXAA
 
+
+check_defined = \
+    $(strip $(foreach 1,$1, \
+    $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+    $(error Undefined make flag: $1$(if $2, ($2))))
+
 .PHONY: dfu-gen dfu-flash
 
 dfu-gen:
 	nrfutil dfu genpkg --dev-type 0x0052 --application $(BUILD)/$(OUTPUT_FILENAME).hex $(BUILD)/dfu-package.zip
 
 dfu-flash:
-	sudo nrfutil dfu serial --package $(BUILD)/dfu-package.zip -p /dev/ttyACM3
+	@:$(call check_defined, SERIAL, example: SERIAL=/dev/ttyUSB0)
+	sudo nrfutil dfu serial --package $(BUILD)/dfu-package.zip -p $(SERIAL)


### PR DESCRIPTION
If not SERIAL flag is supplied this will be the error:

$ make BOARD=feather52 dfu-flash
Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
boards/feather52/mpconfigboard.mk:24: *** Undefined make flag: SERIAL (example: SERIAL=/dev/ttyUSB0).  Stop.

