### PR TITLE
Leds update

### DIFF
--- a/nrf5/boards/feather52/mpconfigboard.h
+++ b/nrf5/boards/feather52/mpconfigboard.h
@@ -38,6 +38,7 @@
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
 
+#define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)
 #define MICROPY_HW_HAS_FLASH        (0)
 #define MICROPY_HW_HAS_SDCARD       (0)

--- a/nrf5/boards/microbit/mpconfigboard.h
+++ b/nrf5/boards/microbit/mpconfigboard.h
@@ -39,6 +39,7 @@
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
 
+#define MICROPY_HW_HAS_LED          (0)
 #define MICROPY_HW_HAS_SWITCH       (0)
 #define MICROPY_HW_HAS_FLASH        (0)
 #define MICROPY_HW_HAS_SDCARD       (0)
@@ -51,13 +52,6 @@
 #define MICROPY_HW_ENABLE_SERVO     (0)
 #define MICROPY_HW_ENABLE_DAC       (0)
 #define MICROPY_HW_ENABLE_CAN       (0)
-
-#define MICROPY_HW_LED_PULLUP       (1)
-
-#define MICROPY_HW_LED1             (21) // LED1
-#define MICROPY_HW_LED2             (22) // LED2
-#define MICROPY_HW_LED3             (23) // LED3
-#define MICROPY_HW_LED4             (24) // LED4
 
 // UART config
 #define MICROPY_HW_UART1_RX         (pin_A25)
@@ -72,5 +66,3 @@
 
 // micro:bit music pin
 #define MICROPY_HW_MUSIC_PIN        (pin_A3)
-
-#define HELP_TEXT_BOARD_LED         "1,2,3,4"

--- a/nrf5/boards/pca10000/mpconfigboard.h
+++ b/nrf5/boards/pca10000/mpconfigboard.h
@@ -33,6 +33,7 @@
 #define MICROPY_PY_MACHINE_HW_SPI   (0)
 #define MICROPY_PY_MACHINE_TEMP     (1)
 
+#define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)
 #define MICROPY_HW_HAS_FLASH        (0)
 #define MICROPY_HW_HAS_SDCARD       (0)

--- a/nrf5/boards/pca10001/mpconfigboard.h
+++ b/nrf5/boards/pca10001/mpconfigboard.h
@@ -33,6 +33,7 @@
 #define MICROPY_PY_MACHINE_HW_SPI   (0)
 #define MICROPY_PY_MACHINE_TEMP     (1)
 
+#define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)
 #define MICROPY_HW_HAS_FLASH        (0)
 #define MICROPY_HW_HAS_SDCARD       (0)

--- a/nrf5/boards/pca10028/mpconfigboard.h
+++ b/nrf5/boards/pca10028/mpconfigboard.h
@@ -37,6 +37,7 @@
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
 
+#define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)
 #define MICROPY_HW_HAS_FLASH        (0)
 #define MICROPY_HW_HAS_SDCARD       (0)
@@ -50,6 +51,7 @@
 #define MICROPY_HW_ENABLE_DAC       (0)
 #define MICROPY_HW_ENABLE_CAN       (0)
 
+#define MICROPY_HW_LED_COUNT        (4)
 #define MICROPY_HW_LED_PULLUP       (1)
 
 #define MICROPY_HW_LED1             (21) // LED1

--- a/nrf5/boards/pca10031/mpconfigboard.h
+++ b/nrf5/boards/pca10031/mpconfigboard.h
@@ -32,6 +32,7 @@
 
 #define MICROPY_PY_MACHINE_TEMP     (1)
 
+#define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)
 #define MICROPY_HW_HAS_FLASH        (0)
 #define MICROPY_HW_HAS_SDCARD       (0)

--- a/nrf5/boards/pca10040/mpconfigboard.h
+++ b/nrf5/boards/pca10040/mpconfigboard.h
@@ -38,6 +38,7 @@
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
 
+#define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)
 #define MICROPY_HW_HAS_FLASH        (0)
 #define MICROPY_HW_HAS_SDCARD       (0)

--- a/nrf5/boards/pca10040/mpconfigboard.h
+++ b/nrf5/boards/pca10040/mpconfigboard.h
@@ -51,6 +51,7 @@
 #define MICROPY_HW_ENABLE_DAC       (0)
 #define MICROPY_HW_ENABLE_CAN       (0)
 
+#define MICROPY_HW_LED_COUNT        (4)
 #define MICROPY_HW_LED_PULLUP       (1)
 
 #define MICROPY_HW_LED1             (17) // LED1

--- a/nrf5/boards/pca10056/mpconfigboard.h
+++ b/nrf5/boards/pca10056/mpconfigboard.h
@@ -36,6 +36,7 @@
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
 
+#define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)
 #define MICROPY_HW_HAS_FLASH        (0)
 #define MICROPY_HW_HAS_SDCARD       (0)
@@ -49,6 +50,7 @@
 #define MICROPY_HW_ENABLE_DAC       (0)
 #define MICROPY_HW_ENABLE_CAN       (0)
 
+#define MICROPY_HW_LED_COUNT        (4)
 #define MICROPY_HW_LED_PULLUP       (1)
 
 #define MICROPY_HW_LED1             (13) // LED1

--- a/nrf5/hal/hal_gpio.h
+++ b/nrf5/hal/hal_gpio.h
@@ -91,13 +91,11 @@ static inline void hal_gpio_pin_clear(uint8_t port, uint32_t pin) {
 }
 
 static inline void hal_gpio_pin_toggle(uint8_t port, uint32_t pin) {
-    uint32_t pin_mask = (1 << pin);
+    uint32_t pin_mask   = (1 << pin);
+    uint32_t pins_state = NRF_GPIO->OUT;
 
-    if (GPIO_BASE(port)->OUT ^ pin_mask) {
-        GPIO_BASE(port)->OUTSET = pin_mask;
-    } else {
-        GPIO_BASE(port)->OUTCLR = pin_mask;
-    }
+    GPIO_BASE(port)->OUTSET = (~pins_state) & pin_mask;
+    GPIO_BASE(port)->OUTCLR = pins_state & pin_mask;
 }
 
 typedef enum {

--- a/nrf5/help.c
+++ b/nrf5/help.c
@@ -37,8 +37,10 @@ const char * nrf5_help_text =
 "For online help please visit http://micropython.org/help/.\n"
 "\n"
 "Quick overview of commands for the board:\n"
+#if MICROPY_HW_HAS_LED
 "  pyb.LED(n)    -- create an LED object for LED n (n=" HELP_TEXT_BOARD_LED ")\n"
 "\n"
+#endif
 #if BLUETOOTH_SD
 HELP_TEXT_SD
 #endif

--- a/nrf5/main.c
+++ b/nrf5/main.c
@@ -90,7 +90,6 @@ soft_reset:
     // to recover from limit hit.  (Limit is measured in bytes.)
     mp_stack_set_limit((char*)&_ram_end - (char*)&_heap_end - 400);
 
-    led_init();
     machine_init();
 
     gc_init(&_heap_start, &_heap_end);
@@ -171,11 +170,9 @@ pin_init0();
     }
 #endif
 
-#if MICROPY_HW_LED_TRICOLOR
-    do_str("import pyb\r\n" \
-           "pyb.LED(1).on()",
-           MP_PARSE_FILE_INPUT);
-#elif (MICROPY_HW_LED_COUNT > 0)
+#if (MICROPY_HW_HAS_LED)
+    led_init();
+
     do_str("import pyb\r\n" \
            "pyb.LED(1).on()",
            MP_PARSE_FILE_INPUT);

--- a/nrf5/main.c
+++ b/nrf5/main.c
@@ -175,14 +175,9 @@ pin_init0();
     do_str("import pyb\r\n" \
            "pyb.LED(1).on()",
            MP_PARSE_FILE_INPUT);
-#elif (MICROPY_HW_LED_COUNT == 2)
+#elif (MICROPY_HW_LED_COUNT > 0)
     do_str("import pyb\r\n" \
            "pyb.LED(1).on()",
-           MP_PARSE_FILE_INPUT);
-#else
-    do_str("import pyb\r\n" \
-           "pyb.LED(1).on()\r\n" \
-           "pyb.LED(3).on()",
            MP_PARSE_FILE_INPUT);
 #endif
 

--- a/nrf5/modules/machine/led.c
+++ b/nrf5/modules/machine/led.c
@@ -31,6 +31,8 @@
 #include "led.h"
 #include "mpconfigboard.h"
 
+#if MICROPY_HW_HAS_LED
+
 #define LED_OFF(led) {(MICROPY_HW_LED_PULLUP) ? hal_gpio_pin_set(0, led) : hal_gpio_pin_clear(0, led); }
 #define LED_ON(led) {(MICROPY_HW_LED_PULLUP) ? hal_gpio_pin_clear(0, led) : hal_gpio_pin_set(0, led); }
 
@@ -154,3 +156,4 @@ const mp_obj_type_t pyb_led_type = {
     .locals_dict = (mp_obj_dict_t*)&led_locals_dict,
 };
 
+#endif // MICROPY_HW_HAS_LED

--- a/nrf5/modules/pyb/modpyb.c
+++ b/nrf5/modules/pyb/modpyb.c
@@ -32,11 +32,17 @@
 #include "nrf.h" // TODO: figure out where to put this import
 #include "pin.h"
 
+#if MICROPY_HW_HAS_LED
+#define PYB_LED_MODULE { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pyb_led_type) },
+#else
+#define PYB_LED_MODULE
+#endif
+
 STATIC const mp_rom_map_elem_t pyb_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_pyb) },
-    { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pyb_led_type) },
     { MP_ROM_QSTR(MP_QSTR_repl_info), MP_ROM_PTR(&pyb_set_repl_info_obj) },
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&pin_type) },
+    PYB_LED_MODULE
 /*    { MP_ROM_QSTR(MP_QSTR_main), MP_ROM_PTR(&pyb_main_obj) }*/
 };
 

--- a/nrf5/mpconfigport.h
+++ b/nrf5/mpconfigport.h
@@ -116,6 +116,14 @@
 #define MICROPY_PY_MACHINE_SPI_MIN_DELAY (0)
 #define MICROPY_PY_FRAMEBUF         (0)
 
+#ifndef MICROPY_HW_LED_COUNT
+#define MICROPY_HW_LED_COUNT        (0)
+#endif
+
+#ifndef MICROPY_HW_LED_PULLUP
+#define MICROPY_HW_LED_PULLUP       (0)
+#endif
+
 #ifndef MICROPY_PY_MUSIC
 #define MICROPY_PY_MUSIC            (0)
 #endif


### PR DESCRIPTION
Update of LED related modules and config. This patch provides option to exclude the pyb.LED module in the case where the board does not have any LED's (microbit for now). Also it cleans up the main.c to not be aware of exactly how many LED's that are present on the board in the do_compile script example. No distinction is done between RGB and binary LED's as RGB leds are mapped to LED1-3.

microbit board config is also cleaned up by removing LED count and LED pin defines.
