### PR TITLE
nrf: Use the name MicroPython consistently in comments

### DIFF
--- a/nrf/README.md
+++ b/nrf/README.md
@@ -17,7 +17,7 @@ This is a port of MicroPython to the Nordic Semiconductor nRF series of chips.
   * Peripheral role on nrf51 targets
   * Central role and Peripheral role on nrf52 targets
   * _REPL over Bluetooth LE_ (optionally using WebBluetooth)
-  * ubluepy: Bluetooth LE module for micropython
+  * ubluepy: Bluetooth LE module for MicroPython
   * 1 non-connectable advertiser while in connection
 
 ## Tested Hardware

--- a/nrf/boards/dvk_bl652/mpconfigboard.h
+++ b/nrf/boards/dvk_bl652/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/boards/feather52/mpconfigboard.h
+++ b/nrf/boards/feather52/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/boards/microbit/mpconfigboard.h
+++ b/nrf/boards/microbit/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/boards/pca10000/mpconfigboard.h
+++ b/nrf/boards/pca10000/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/boards/pca10001/mpconfigboard.h
+++ b/nrf/boards/pca10001/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/boards/pca10028/mpconfigboard.h
+++ b/nrf/boards/pca10028/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/boards/pca10031/mpconfigboard.h
+++ b/nrf/boards/pca10031/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/boards/pca10040/mpconfigboard.h
+++ b/nrf/boards/pca10040/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/boards/pca10056/mpconfigboard.h
+++ b/nrf/boards/pca10056/mpconfigboard.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/device/nrf51/startup_nrf51822.c
+++ b/nrf/device/nrf51/startup_nrf51822.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/device/nrf52/startup_nrf52832.c
+++ b/nrf/device/nrf52/startup_nrf52832.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/device/nrf52/startup_nrf52840.c
+++ b/nrf/device/nrf52/startup_nrf52840.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/drivers/bluetooth/ble_drv.c
+++ b/nrf/drivers/bluetooth/ble_drv.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/drivers/bluetooth/ble_drv.h
+++ b/nrf/drivers/bluetooth/ble_drv.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/drivers/bluetooth/ble_uart.c
+++ b/nrf/drivers/bluetooth/ble_uart.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/drivers/bluetooth/ble_uart.h
+++ b/nrf/drivers/bluetooth/ble_uart.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/drivers/softpwm.c
+++ b/nrf/drivers/softpwm.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/drivers/ticker.c
+++ b/nrf/drivers/ticker.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/examples/nrf52_servo.py
+++ b/nrf/examples/nrf52_servo.py
@@ -1,4 +1,4 @@
-# This file is part of the Micro Python project, http://micropython.org/
+# This file is part of the MicroPython project, http://micropython.org/
 #
 # The MIT License (MIT)
 #

--- a/nrf/examples/powerup.py
+++ b/nrf/examples/powerup.py
@@ -1,4 +1,4 @@
-# This file is part of the Micro Python project, http://micropython.org/
+# This file is part of the MicroPython project, http://micropython.org/
 #
 # The MIT License (MIT)
 #

--- a/nrf/examples/seeed_tft.py
+++ b/nrf/examples/seeed_tft.py
@@ -1,4 +1,4 @@
-# This file is part of the Micro Python project, http://micropython.org/
+# This file is part of the MicroPython project, http://micropython.org/
 #
 # The MIT License (MIT)
 #

--- a/nrf/examples/ubluepy_temp.py
+++ b/nrf/examples/ubluepy_temp.py
@@ -1,4 +1,4 @@
-# This file is part of the Micro Python project, http://micropython.org/
+# This file is part of the MicroPython project, http://micropython.org/
 #
 # The MIT License (MIT)
 #

--- a/nrf/gccollect.c
+++ b/nrf/gccollect.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/gccollect.h
+++ b/nrf/gccollect.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_adc.c
+++ b/nrf/hal/hal_adc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_adc.h
+++ b/nrf/hal/hal_adc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_adce.c
+++ b/nrf/hal/hal_adce.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_gpio.c
+++ b/nrf/hal/hal_gpio.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_gpio.h
+++ b/nrf/hal/hal_gpio.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_irq.h
+++ b/nrf/hal/hal_irq.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_pwm.c
+++ b/nrf/hal/hal_pwm.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_pwm.h
+++ b/nrf/hal/hal_pwm.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_qspie.c
+++ b/nrf/hal/hal_qspie.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_qspie.h
+++ b/nrf/hal/hal_qspie.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_rtc.c
+++ b/nrf/hal/hal_rtc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_rtc.h
+++ b/nrf/hal/hal_rtc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_spi.c
+++ b/nrf/hal/hal_spi.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_spi.h
+++ b/nrf/hal/hal_spi.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_spie.c
+++ b/nrf/hal/hal_spie.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_temp.c
+++ b/nrf/hal/hal_temp.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_temp.h
+++ b/nrf/hal/hal_temp.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_time.c
+++ b/nrf/hal/hal_time.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_time.h
+++ b/nrf/hal/hal_time.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_timer.c
+++ b/nrf/hal/hal_timer.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_timer.h
+++ b/nrf/hal/hal_timer.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_twi.c
+++ b/nrf/hal/hal_twi.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_twi.h
+++ b/nrf/hal/hal_twi.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_twie.c
+++ b/nrf/hal/hal_twie.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_uart.c
+++ b/nrf/hal/hal_uart.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_uart.h
+++ b/nrf/hal/hal_uart.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/hal_uarte.c
+++ b/nrf/hal/hal_uarte.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/nrf51_hal.h
+++ b/nrf/hal/nrf51_hal.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/hal/nrf52_hal.h
+++ b/nrf/hal/nrf52_hal.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/help.c
+++ b/nrf/help.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/main.c
+++ b/nrf/main.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ble/help_sd.h
+++ b/nrf/modules/ble/help_sd.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ble/modble.c
+++ b/nrf/modules/ble/modble.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/adc.c
+++ b/nrf/modules/machine/adc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/adc.h
+++ b/nrf/modules/machine/adc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/i2c.c
+++ b/nrf/modules/machine/i2c.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/i2c.h
+++ b/nrf/modules/machine/i2c.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/led.c
+++ b/nrf/modules/machine/led.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -85,7 +85,7 @@ void led_toggle(pyb_led_obj_t * led_obj) {
 
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 void led_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_led_obj_t *self = self_in;

--- a/nrf/modules/machine/led.h
+++ b/nrf/modules/machine/led.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/modmachine.c
+++ b/nrf/modules/machine/modmachine.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/modmachine.h
+++ b/nrf/modules/machine/modmachine.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/pin.c
+++ b/nrf/modules/machine/pin.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/pin.h
+++ b/nrf/modules/machine/pin.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/pwm.c
+++ b/nrf/modules/machine/pwm.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/pwm.h
+++ b/nrf/modules/machine/pwm.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/rtc.c
+++ b/nrf/modules/machine/rtc.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/rtc.h
+++ b/nrf/modules/machine/rtc.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/spi.c
+++ b/nrf/modules/machine/spi.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/spi.h
+++ b/nrf/modules/machine/spi.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/temp.c
+++ b/nrf/modules/machine/temp.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/temp.h
+++ b/nrf/modules/machine/temp.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/timer.c
+++ b/nrf/modules/machine/timer.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/timer.h
+++ b/nrf/modules/machine/timer.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/machine/uart.c
+++ b/nrf/modules/machine/uart.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -118,7 +118,7 @@ void uart_tx_strn_cooked(machine_hard_uart_obj_t *uart_obj, const char *str, uin
 }
 
 /******************************************************************************/
-/* Micro Python bindings                                                      */
+/* MicroPython bindings                                                      */
 
 STATIC void machine_hard_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
 }

--- a/nrf/modules/machine/uart.h
+++ b/nrf/modules/machine/uart.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/music/modmusic.c
+++ b/nrf/modules/music/modmusic.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/music/musictunes.c
+++ b/nrf/modules/music/musictunes.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The music encoded herein is either in the public domain, composed by
  * Nicholas H.Tollervey or the composer is untraceable and covered by fair

--- a/nrf/modules/music/musictunes.h
+++ b/nrf/modules/music/musictunes.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/pyb/modpyb.c
+++ b/nrf/modules/pyb/modpyb.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/modubluepy.c
+++ b/nrf/modules/ubluepy/modubluepy.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/modubluepy.h
+++ b/nrf/modules/ubluepy/modubluepy.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/ubluepy_characteristic.c
+++ b/nrf/modules/ubluepy/ubluepy_characteristic.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/ubluepy_constants.c
+++ b/nrf/modules/ubluepy/ubluepy_constants.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/ubluepy_delegate.c
+++ b/nrf/modules/ubluepy/ubluepy_delegate.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/ubluepy_descriptor.c
+++ b/nrf/modules/ubluepy/ubluepy_descriptor.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/ubluepy_peripheral.c
+++ b/nrf/modules/ubluepy/ubluepy_peripheral.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/ubluepy_scan_entry.c
+++ b/nrf/modules/ubluepy/ubluepy_scan_entry.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/ubluepy_scanner.c
+++ b/nrf/modules/ubluepy/ubluepy_scanner.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/ubluepy_service.c
+++ b/nrf/modules/ubluepy/ubluepy_service.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/ubluepy/ubluepy_uuid.c
+++ b/nrf/modules/ubluepy/ubluepy_uuid.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/uos/moduos.c
+++ b/nrf/modules/uos/moduos.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/modules/utime/modutime.c
+++ b/nrf/modules/utime/modutime.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/mpconfigport.h
+++ b/nrf/mpconfigport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *
@@ -29,7 +29,7 @@
 
 #include <mpconfigboard.h>
 
-// options to control how Micro Python is built
+// options to control how MicroPython is built
 #define MICROPY_ALLOC_PATH_MAX      (512)
 #define MICROPY_PERSISTENT_CODE_LOAD (0)
 #define MICROPY_EMIT_THUMB          (0)

--- a/nrf/mphalport.c
+++ b/nrf/mphalport.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/mphalport.h
+++ b/nrf/mphalport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/pin_defs_nrf5.h
+++ b/nrf/pin_defs_nrf5.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/pin_named_pins.c
+++ b/nrf/pin_named_pins.c
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *

--- a/nrf/qstrdefsport.h
+++ b/nrf/qstrdefsport.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the Micro Python project, http://micropython.org/
+ * This file is part of the MicroPython project, http://micropython.org/
  *
  * The MIT License (MIT)
  *


### PR DESCRIPTION
There were several different spellings of MicroPython present in comments,
when there should be only one.

Aligning to upstream commit 55f33240f3d7051d4213629e92437a36f1fac50e.