### PR TITLE
nrf/hal/rng: Adding HAL driver for accessing RNG peripheral

### DIFF
--- a/nrf/Makefile
+++ b/nrf/Makefile
@@ -114,6 +114,7 @@ SRC_HAL = $(addprefix hal/,\
 	hal_adce.c \
 	hal_temp.c \
 	hal_gpio.c \
+	hal_rng.c \
 	)
 
 ifeq ($(MCU_VARIANT), nrf52)

--- a/nrf/hal/hal_rng.c
+++ b/nrf/hal/hal_rng.c
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Glenn Ruben Bakke
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "mphalport.h"
+#include "hal_rng.h"
+
+#ifdef HAL_RNG_MODULE_ENABLED
+
+uint8_t hal_rng_generate(uint16_t num_of_loops) {
+}
+
+#endif // HAL_RNG_MODULE_ENABLED
+

--- a/nrf/hal/hal_rng.c
+++ b/nrf/hal/hal_rng.c
@@ -47,7 +47,7 @@ uint32_t hal_rng_generate(void) {
     if (BLUETOOTH_STACK_ENABLED() == 1) {
         uint32_t status;
         do {
-            status = sd_rand_application_vector_get(&retval, 4); // Extract 4 bytes
+            status = sd_rand_application_vector_get((uint8_t *)&retval, 4); // Extract 4 bytes
         } while (status != 0);
 
 	return retval;

--- a/nrf/hal/hal_rng.c
+++ b/nrf/hal/hal_rng.c
@@ -38,7 +38,7 @@
 
 #endif // BLUETOOTH_SD
 
-uint32_t hal_rng_generate(uint16_t num_of_loops) {
+uint32_t hal_rng_generate(void) {
 
     uint32_t retval = 0;
 

--- a/nrf/hal/hal_rng.c
+++ b/nrf/hal/hal_rng.c
@@ -51,25 +51,26 @@ uint32_t hal_rng_generate(void) {
         } while (status != 0);
 
 	return retval;
-    }
-
+    } else {
 #else
+        uint8_t * p_retval = (uint8_t *)&retval;
 
-    uint8_t * p_retval = (uint8_t *)&retval;
-
-    NRF_RNG->EVENTS_VALRDY = 0;
-    NRF_RNG->TASKS_START   = 1;
-
-    for (uint16_t i = 0; i < 4; i++) {
-        while (NRF_RNG->EVENTS_VALRDY == 0) {
-            ;
-        }
         NRF_RNG->EVENTS_VALRDY = 0;
-	p_retval[i] = NRF_RNG->VALUE;
+        NRF_RNG->TASKS_START   = 1;
+
+        for (uint16_t i = 0; i < 4; i++) {
+            while (NRF_RNG->EVENTS_VALRDY == 0) {
+                ;
+            }
+            NRF_RNG->EVENTS_VALRDY = 0;
+            p_retval[i] = NRF_RNG->VALUE;
+        }
+
+        NRF_RNG->TASKS_STOP = 1;
+#endif
+
+#if BLUETOOTH_SD
     }
-
-    NRF_RNG->TASKS_STOP = 1;
-
 #endif
 
     return retval;

--- a/nrf/hal/hal_rng.c
+++ b/nrf/hal/hal_rng.c
@@ -30,6 +30,22 @@
 #ifdef HAL_RNG_MODULE_ENABLED
 
 uint8_t hal_rng_generate(uint16_t num_of_loops) {
+
+    NRF_RNG->EVENTS_VALRDY = 0;
+    NRF_RNG->TASKS_START   = 1;
+    
+    for (uint16_t i = 0; i < num_of_loops; i++) {
+
+        while (NRF_RNG->EVENTS_VALRDY == 0) {
+            ;
+        }
+
+        NRF_RNG->EVENTS_VALRDY = 0;
+    }
+
+    NRF_RNG->TASKS_STOP = 1;
+
+    return NRF_RNG->VALUE;
 }
 
 #endif // HAL_RNG_MODULE_ENABLED

--- a/nrf/hal/hal_rng.c
+++ b/nrf/hal/hal_rng.c
@@ -49,10 +49,8 @@ uint32_t hal_rng_generate(void) {
         do {
             status = sd_rand_application_vector_get((uint8_t *)&retval, 4); // Extract 4 bytes
         } while (status != 0);
-
-	return retval;
     } else {
-#else
+#endif
         uint8_t * p_retval = (uint8_t *)&retval;
 
         NRF_RNG->EVENTS_VALRDY = 0;
@@ -67,8 +65,6 @@ uint32_t hal_rng_generate(void) {
         }
 
         NRF_RNG->TASKS_STOP = 1;
-#endif
-
 #if BLUETOOTH_SD
     }
 #endif

--- a/nrf/hal/hal_rng.c
+++ b/nrf/hal/hal_rng.c
@@ -33,7 +33,7 @@ uint8_t hal_rng_generate(uint16_t num_of_loops) {
 
     NRF_RNG->EVENTS_VALRDY = 0;
     NRF_RNG->TASKS_START   = 1;
-    
+
     for (uint16_t i = 0; i < num_of_loops; i++) {
 
         while (NRF_RNG->EVENTS_VALRDY == 0) {

--- a/nrf/hal/hal_rng.h
+++ b/nrf/hal/hal_rng.h
@@ -29,6 +29,6 @@
 
 #include "nrf.h"
 
-uint32_t hal_rng_generate(uint16_t num_of_loops);
+uint32_t hal_rng_generate(void);
 
 #endif // HAL_RNG_H__

--- a/nrf/hal/hal_rng.h
+++ b/nrf/hal/hal_rng.h
@@ -29,6 +29,6 @@
 
 #include "nrf.h"
 
-uint8_t hal_rng_generate(uint16_t num_of_loops);
+uint32_t hal_rng_generate(uint16_t num_of_loops);
 
 #endif // HAL_RNG_H__

--- a/nrf/hal/hal_rng.h
+++ b/nrf/hal/hal_rng.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Glenn Ruben Bakke
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef HAL_RNG_H__
+#define HAL_RNG_H__
+
+#include "nrf.h"
+
+uint8_t hal_rng_generate(uint16_t num_of_loops);
+
+#endif // HAL_RNG_H__

--- a/nrf/mpconfigport.h
+++ b/nrf/mpconfigport.h
@@ -156,6 +156,10 @@
 #define MICROPY_PY_MACHINE_RTC      (0)
 #endif
 
+#ifndef MICROPY_PY_HW_RNG
+#define MICROPY_PY_HW_RNG           (0)
+#endif
+
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF   (1)
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE  (0)
 

--- a/nrf/mpconfigport.h
+++ b/nrf/mpconfigport.h
@@ -156,10 +156,6 @@
 #define MICROPY_PY_MACHINE_RTC      (0)
 #endif
 
-#ifndef MICROPY_PY_HW_RNG
-#define MICROPY_PY_HW_RNG           (0)
-#endif
-
 #define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF   (1)
 #define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE  (0)
 


### PR DESCRIPTION
The driver also takes care of calling the Bluetooth LE stack for random values if the stack is enabled. The reason for this is that the Bluetooth LE stack take ownership of the NRF_RNG when enabled. Tolerate to enable/disable on the fly, and will choose to use direct access to the peripheral if Bluetooth LE stack is disabled or not compiled in at all.

Driver has been included in the top Makefile, and will not be compiled in unless nrf51_hal_conf.h/nrf52_hal_conf.h defines HAL_RNG_MODULE_ENABLED (1).