### PR TITLE
ports/nrf: Enable Link-time optimizations

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -74,14 +74,13 @@ CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
 CFLAGS += $(INC) -Wall -Werror -ansi -std=gnu99 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD)
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -fstack-usage
-CFLAGS += -fdata-sections -ffunction-sections
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'
+CFLAGS += -flto
 
 LDFLAGS = $(CFLAGS)
 LDFLAGS += -Xlinker -Map=$(@:.elf=.map)
 LDFLAGS += -mthumb -mabi=aapcs -T $(LD_FILE) -L boards/
-LDFLAGS += -Wl,--gc-sections
 
 #Debugging/Optimization
 ifeq ($(DEBUG), 1)

--- a/ports/nrf/device/nrf51/startup_nrf51822.c
+++ b/ports/nrf/device/nrf51/startup_nrf51822.c
@@ -103,7 +103,7 @@ void SWI3_IRQHandler        (void) __attribute__ ((weak, alias("Default_Handler"
 void SWI4_IRQHandler        (void) __attribute__ ((weak, alias("Default_Handler")));
 void SWI5_IRQHandler        (void) __attribute__ ((weak, alias("Default_Handler")));
 
-const func __Vectors[] __attribute__ ((section(".isr_vector"))) = {
+const func __Vectors[] __attribute__ ((section(".isr_vector"),used)) = {
     (func)&_estack,
     Reset_Handler,
     NMI_Handler,

--- a/ports/nrf/device/nrf52/startup_nrf52832.c
+++ b/ports/nrf/device/nrf52/startup_nrf52832.c
@@ -107,7 +107,7 @@ void SPIM2_SPIS2_SPI2_IRQHandler (void) __attribute__ ((weak, alias("Default_Han
 void RTC2_IRQHandler          (void) __attribute__ ((weak, alias("Default_Handler")));
 void I2S_IRQHandler           (void) __attribute__ ((weak, alias("Default_Handler")));
 
-const func __Vectors[] __attribute__ ((section(".isr_vector"))) = {
+const func __Vectors[] __attribute__ ((section(".isr_vector"),used)) = {
     (func)&_estack,
     Reset_Handler,
     NMI_Handler,

--- a/ports/nrf/device/nrf52/startup_nrf52840.c
+++ b/ports/nrf/device/nrf52/startup_nrf52840.c
@@ -114,7 +114,7 @@ void CRYPTOCELL_IRQHandler       (void) __attribute__ ((weak, alias("Default_Han
 void SPIM3_IRQHandler            (void) __attribute__ ((weak, alias("Default_Handler")));
 void PWM3_IRQHandler             (void) __attribute__ ((weak, alias("Default_Handler")));
 
-const func __Vectors[] __attribute__ ((section(".isr_vector"))) = {
+const func __Vectors[] __attribute__ ((section(".isr_vector"),used)) = {
     (func)&_estack,
     Reset_Handler,
     NMI_Handler,


### PR DESCRIPTION
I was experimenting with LTO. I've got it working for nRF51 without SoftDevice but couldn't get it to work when it is compiled with a SoftDevice (goes straight to a HardFault). Nonetheless, I wanted to share what I've got so far, if you're interested. Of course, it will need a lot of testing, as LTO support is relatively new and no other ports have implemented it.

It saves roughly 1kB of flash and 52 (?) bytes of RAM.