### PR TITLE
ports/nrf: Disable FAT/VFS by default.

### DIFF
--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -31,7 +31,7 @@
 
 // options to control how MicroPython is built
 #ifndef MICROPY_VFS
-#define MICROPY_VFS                 (1)
+#define MICROPY_VFS                 (0)
 #endif
 #define MICROPY_VFS_FAT             (MICROPY_VFS)
 #define MICROPY_ALLOC_PATH_MAX      (512)


### PR DESCRIPTION
Most boards don't have an SD card so it makes no sense to have it enabled. It can be enabled per board (mpconfigboard.h).

This commit probably needs to be rebased after #121 is merged, but I'm doing the pull request now for review.

Fixes #120 