### PR TITLE
ports/nrf/hal/nvmc: Enable hal_nvmc support on nrf52

### DIFF
--- a/ports/nrf/hal/hal_nvmc.h
+++ b/ports/nrf/hal/hal_nvmc.h
@@ -59,8 +59,6 @@ enum {
 
 #elif defined(NRF52)
 #define HAL_NVMC_PAGESIZE (4096)
-#error NRF52 not yet implemented
-
 #else
 #error Unknown chip
 #endif


### PR DESCRIPTION
Removing pre-compiler error thrown in nvmc.h, if used on nrf52.