### PR TITLE
ports/nrf/main: Run boot.py and main.py on startup.

### DIFF
--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -184,6 +184,16 @@ pin_init0();
            MP_PARSE_FILE_INPUT);
 #endif
 
+#if MICROPY_VFS || MICROPY_HW_HAS_BUILTIN_FLASH
+    // run boot.py and main.py if they exist.
+    if (mp_import_stat("boot.py") == MP_IMPORT_STAT_FILE) {
+        pyexec_file("boot.py");
+    }
+    if (mp_import_stat("main.py") == MP_IMPORT_STAT_FILE) {
+        pyexec_file("main.py");
+    }
+#endif
+
     // Main script is finished, so now go into REPL mode.
     // The REPL mode can change, or it can request a soft reset.
     int ret_code = 0;


### PR DESCRIPTION
Also see #116.