### PR TITLE
ports/nrf/main: Add ampy support.

### DIFF
--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -223,6 +223,7 @@ pin_init0();
     if (ret_code == PYEXEC_FORCED_EXIT) {
         NVIC_SystemReset();
     } else {
+        printf("MPY: soft reboot\n");
         goto soft_reset;
     }
 


### PR DESCRIPTION
The ampy tool expects a "soft reboot" line when it does a soft reset. Also see https://github.com/micropython/micropython/issues/3274#issuecomment-338116089.
So far it works most of the time. It crashed once but that may be due to #89. Still that's an improvement over no support at all.

Code size increases with 28 bytes.

closes #130 