### PR TITLE
[WIP] Enable micro:bit filesystem + VFS support

### DIFF
--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -39,6 +39,8 @@
 #include "py/gc.h"
 #include "py/compile.h"
 #include "lib/utils/pyexec.h"
+#include "extmod/vfs.h"
+#include "modules/uos/microbitfs.h"
 #include "readline.h"
 #include "gccollect.h"
 #include "modmachine.h"
@@ -141,7 +143,16 @@ pin_init0();
 
 #if MICROPY_HW_HAS_BUILTIN_FLASH
     microbit_filesystem_init();
-#endif
+#if MICROPY_VFS
+    mp_vfs_mount_t *vfs = m_new_obj(mp_vfs_mount_t);
+    vfs->str = "/flash";
+    vfs->len = 6; // strlen("/flash");
+    vfs->obj = MP_OBJ_TO_PTR(&uos_mbfs_obj);
+    vfs->next = NULL;
+    MP_STATE_VM(vfs_mount_table) = vfs;
+    MP_STATE_PORT(vfs_cur) = vfs;
+#endif // MICROPY_VFS
+#endif // MICROPY_HW_HAS_BUILTIN_FLASH
 
 #if MICROPY_HW_HAS_SDCARD
     // if an SD card is present then mount it on /sd/

--- a/ports/nrf/modules/uos/microbitfs.h
+++ b/ports/nrf/modules/uos/microbitfs.h
@@ -49,4 +49,10 @@ MP_DECLARE_CONST_FUN_OBJ_0(uos_mbfs_ilistdir_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(uos_mbfs_remove_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(uos_mbfs_stat_obj);
 
+typedef struct {
+    mp_obj_base_t base;
+} uos_mbfs_obj_t;
+
+extern const uos_mbfs_obj_t uos_mbfs_obj;
+
 #endif // __MICROPY_INCLUDED_FILESYSTEM_H__


### PR DESCRIPTION
This patch enables the use of the micro:bit filesystem while VFS is also enabled. The use case is using both internal flash and an SD card. Note that it doesn't enable using FAT on the internal storage, which turned out to be tricky.

TODO:
 - [ ] more testing of internal FS
 - [ ] test with SD card
 - [ ] test use with SoftDevice? (not enough flash)
 - [ ] implement `os.chdir()` etc. - most of these `os.*` functions aren't implemented yet in `mbfs_obj`
 - [ ] maybe store the `vfs` object in `.data` instead of on the heap (might reduce .text size)