### PR TITLE
ports/nrf: Updating use of mp_obj_new_str 

### DIFF
--- a/ports/nrf/modules/ble/modble.c
+++ b/ports/nrf/modules/ble/modble.c
@@ -74,7 +74,7 @@ mp_obj_t ble_obj_address(void) {
                 local_addr.addr[5], local_addr.addr[4], local_addr.addr[3],
                 local_addr.addr[2], local_addr.addr[1], local_addr.addr[0]);
 
-    mp_obj_t mac_str = mp_obj_new_str(vstr.buf, vstr.len, false);
+    mp_obj_t mac_str = mp_obj_new_str(vstr.buf, vstr.len);
 
     vstr_clear(&vstr);
 

--- a/ports/nrf/modules/ubluepy/ubluepy_scan_entry.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_scan_entry.c
@@ -109,7 +109,7 @@ STATIC mp_obj_t scan_entry_get_scan_data(mp_obj_t self_in) {
                 vstr_t vstr;
                 vstr_init(&vstr, len);
                 vstr_printf(&vstr, "%s", text);
-                description = mp_obj_new_str(vstr.buf, vstr.len, false);
+                description = mp_obj_new_str(vstr.buf, vstr.len);
                 vstr_clear(&vstr);
             }
         }

--- a/ports/nrf/modules/ubluepy/ubluepy_scanner.c
+++ b/ports/nrf/modules/ubluepy/ubluepy_scanner.c
@@ -49,7 +49,7 @@ STATIC void adv_event_handler(mp_obj_t self_in, uint16_t event_id, ble_drv_adv_d
                 data->p_peer_addr[5], data->p_peer_addr[4], data->p_peer_addr[3],
                 data->p_peer_addr[2], data->p_peer_addr[1], data->p_peer_addr[0]);
 
-    item->addr = mp_obj_new_str(vstr.buf, vstr.len, false);
+    item->addr = mp_obj_new_str(vstr.buf, vstr.len);
 
     vstr_clear(&vstr);
 

--- a/ports/nrf/modules/uos/microbitfs.c
+++ b/ports/nrf/modules/uos/microbitfs.c
@@ -324,7 +324,7 @@ STATIC uint8_t find_chunk_and_erase(void) {
 }
 
 STATIC mp_obj_t microbit_file_name(file_descriptor_obj *fd) {
-    return mp_obj_new_str(&(file_system_chunks[fd->start_chunk].header.filename[0]), file_system_chunks[fd->start_chunk].header.name_len, false);
+    return mp_obj_new_str(&(file_system_chunks[fd->start_chunk].header.filename[0]), file_system_chunks[fd->start_chunk].header.name_len);
 }
 
 STATIC file_descriptor_obj *microbit_file_descriptor_new(uint8_t start_chunk, bool write, bool binary);
@@ -481,7 +481,7 @@ STATIC mp_obj_t microbit_file_list(void) {
     mp_obj_t res = mp_obj_new_list(0, NULL);
     for (uint8_t index = 1; index <= chunks_in_file_system; index++) {
         if (file_system_chunks[index].marker == FILE_START) {
-            mp_obj_t name = mp_obj_new_str(&file_system_chunks[index].header.filename[0], file_system_chunks[index].header.name_len, false);
+            mp_obj_t name = mp_obj_new_str(&file_system_chunks[index].header.filename[0], file_system_chunks[index].header.name_len);
             mp_obj_list_append(res, name);
         }
     }
@@ -585,7 +585,7 @@ STATIC mp_obj_t uos_mbfs_ilistdir_it_iternext(mp_obj_t self_in) {
         }
 
         // Get the file name as str object.
-        mp_obj_t name = mp_obj_new_str(&file_system_chunks[self->index].header.filename[0], file_system_chunks[self->index].header.name_len, false);
+        mp_obj_t name = mp_obj_new_str(&file_system_chunks[self->index].header.filename[0], file_system_chunks[self->index].header.name_len);
 
         // make 3-tuple with info about this entry
         mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(3, NULL));


### PR DESCRIPTION
Updating use of mp_obj_new_str by removing last parameter. Alignment triggered by merge with upstream master.