### PR TITLE
ports/nrf/boards/microbit: Enable music, display, microbit module

### DIFF
--- a/ports/nrf/boards/microbit/mpconfigboard.h
+++ b/ports/nrf/boards/microbit/mpconfigboard.h
@@ -30,8 +30,8 @@
 #define MICROPY_HW_MCU_NAME         "NRF51822"
 #define MICROPY_PY_SYS_PLATFORM     "nrf51"
 
-#define MICROPY_PY_MUSIC            (0)
-#define MICROPY_PY_MACHINE_SOFT_PWM (0)
+#define MICROPY_PY_MUSIC            (1)
+#define MICROPY_PY_MACHINE_SOFT_PWM (1)
 #define MICROPY_PY_MACHINE_HW_SPI   (1)
 #define MICROPY_PY_MACHINE_TIMER    (1)
 #define MICROPY_PY_MACHINE_RTC      (1)


### PR DESCRIPTION
Also enabling softpwm driver which is a requirement for display and music.