### PR TITLE
ports/nrf/hal/twi: Add return of error code from TWI write/read

### DIFF
--- a/ports/nrf/hal/hal_twi.c
+++ b/ports/nrf/hal/hal_twi.c
@@ -33,6 +33,13 @@
                                 TWI_ERRORSRC_ANACK_Msk | \
                                 TWI_ERRORSRC_OVERRUN_Msk)
 
+#define HAL_TWI_PIN_CONFIG(pin) \
+    NRF_GPIO->PIN_CNF[pin] = ((GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos)   \
+                            | (GPIO_PIN_CNF_DRIVE_S0D1     << GPIO_PIN_CNF_DRIVE_Pos)   \
+                            | (GPIO_PIN_CNF_PULL_Pullup    << GPIO_PIN_CNF_PULL_Pos)    \
+                            | (GPIO_PIN_CNF_INPUT_Connect  << GPIO_PIN_CNF_INPUT_Pos)   \
+                            | (GPIO_PIN_CNF_DIR_Input      << GPIO_PIN_CNF_DIR_Pos))
+
 static const uint32_t hal_twi_frequency_lookup[] = {
     TWI_FREQUENCY_FREQUENCY_K100, // 100 kbps
     TWI_FREQUENCY_FREQUENCY_K250, // 250 kbps
@@ -40,6 +47,9 @@ static const uint32_t hal_twi_frequency_lookup[] = {
 };
 
 void hal_twi_master_init(NRF_TWI_Type * p_instance, hal_twi_init_t const * p_twi_init) {
+
+    HAL_TWI_PIN_CONFIG(p_twi_init->scl_pin->pin);
+    HAL_TWI_PIN_CONFIG(p_twi_init->sda_pin->pin);
 
 #if NRF52840_XXAA
     p_instance->PSEL.SCL  = p_twi_init->scl_pin->pin;

--- a/ports/nrf/hal/hal_twi.c
+++ b/ports/nrf/hal/hal_twi.c
@@ -29,6 +29,8 @@
 
 #ifdef HAL_TWI_MODULE_ENABLED
 
+#define HAL_TWI_ERROR_CLR_MASK (7)
+
 static const uint32_t hal_twi_frequency_lookup[] = {
     TWI_FREQUENCY_FREQUENCY_K100, // 100 kbps
     TWI_FREQUENCY_FREQUENCY_K250, // 250 kbps
@@ -50,16 +52,18 @@ void hal_twi_master_init(NRF_TWI_Type * p_instance, hal_twi_init_t const * p_twi
     p_instance->FREQUENCY = hal_twi_frequency_lookup[p_twi_init->freq];
     p_instance->ENABLE    = (TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos);
 }
-#include <stdio.h>
-void hal_twi_master_tx(NRF_TWI_Type  * p_instance,
-                       uint8_t         addr,
-                       uint16_t        transfer_size,
-                       const uint8_t * tx_data,
-                       bool            stop) {
+
+hal_twi_error_t hal_twi_master_tx(NRF_TWI_Type  * p_instance,
+                                  uint8_t         addr,
+                                  uint16_t        transfer_size,
+                                  const uint8_t * tx_data,
+                                  bool            stop) {
 
     uint16_t number_of_txd_bytes = 0;
 
-    p_instance->ADDRESS = addr;
+    p_instance->ERRORSRC = HAL_TWI_ERROR_CLR_MASK;
+
+    p_instance->ADDRESS  = addr;
 
     p_instance->EVENTS_TXDSENT = 0;
 
@@ -88,15 +92,19 @@ void hal_twi_master_tx(NRF_TWI_Type  * p_instance,
             ;
         }
     }
+
+    return p_instance->ERRORSRC;
 }
 
-void hal_twi_master_rx(NRF_TWI_Type  * p_instance,
-                       uint8_t         addr,
-                       uint16_t        transfer_size,
-                       uint8_t       * rx_data,
-                       bool            stop) {
+hal_twi_error_t hal_twi_master_rx(NRF_TWI_Type  * p_instance,
+                                  uint8_t         addr,
+                                  uint16_t        transfer_size,
+                                  uint8_t       * rx_data,
+                                  bool            stop) {
 
     uint16_t number_of_rxd_bytes = 0;
+
+    p_instance->ERRORSRC = HAL_TWI_ERROR_CLR_MASK;
 
     p_instance->ADDRESS = addr;
 
@@ -124,6 +132,8 @@ void hal_twi_master_rx(NRF_TWI_Type  * p_instance,
             ;
         }
     }
+
+    return p_instance->ERRORSRC;
 }
 
 void hal_twi_slave_init(NRF_TWI_Type * p_instance, hal_twi_init_t const * p_twi_init) {

--- a/ports/nrf/hal/hal_twi.c
+++ b/ports/nrf/hal/hal_twi.c
@@ -74,7 +74,7 @@ hal_twi_error_t hal_twi_master_tx(NRF_TWI_Type  * p_instance,
 
     while (number_of_txd_bytes < transfer_size) {
         // wait for the transaction complete
-        while (p_instance->EVENTS_TXDSENT == 0) {
+        while (p_instance->EVENTS_TXDSENT == 0 || p_instance->ERRORSRC) {
             ;
         }
 
@@ -116,7 +116,7 @@ hal_twi_error_t hal_twi_master_rx(NRF_TWI_Type  * p_instance,
 
     while (number_of_rxd_bytes < transfer_size) {
         // wait for the transaction complete
-        while (p_instance->EVENTS_RXDREADY == 0) {
+        while (p_instance->EVENTS_RXDREADY == 0 || p_instance->ERRORSRC) {
             ;
         }
 

--- a/ports/nrf/hal/hal_twi.c
+++ b/ports/nrf/hal/hal_twi.c
@@ -29,7 +29,9 @@
 
 #ifdef HAL_TWI_MODULE_ENABLED
 
-#define HAL_TWI_ERROR_CLR_MASK (7)
+#define HAL_TWI_ERROR_CLR_MASK (TWI_ERRORSRC_DNACK_Msk | \
+                                TWI_ERRORSRC_ANACK_Msk | \
+                                TWI_ERRORSRC_OVERRUN_Msk)
 
 static const uint32_t hal_twi_frequency_lookup[] = {
     TWI_FREQUENCY_FREQUENCY_K100, // 100 kbps
@@ -55,11 +57,11 @@ void hal_twi_master_init(NRF_TWI_Type * p_instance, hal_twi_init_t const * p_twi
 
 hal_twi_error_t hal_twi_master_tx(NRF_TWI_Type  * p_instance,
                                   uint8_t         addr,
-                                  uint16_t        transfer_size,
+                                  size_t          transfer_size,
                                   const uint8_t * tx_data,
                                   bool            stop) {
 
-    uint16_t number_of_txd_bytes = 0;
+    size_t number_of_txd_bytes = 0;
 
     p_instance->ERRORSRC = HAL_TWI_ERROR_CLR_MASK;
 
@@ -98,11 +100,11 @@ hal_twi_error_t hal_twi_master_tx(NRF_TWI_Type  * p_instance,
 
 hal_twi_error_t hal_twi_master_rx(NRF_TWI_Type  * p_instance,
                                   uint8_t         addr,
-                                  uint16_t        transfer_size,
+                                  size_t          transfer_size,
                                   uint8_t       * rx_data,
                                   bool            stop) {
 
-    uint16_t number_of_rxd_bytes = 0;
+    size_t number_of_rxd_bytes = 0;
 
     p_instance->ERRORSRC = HAL_TWI_ERROR_CLR_MASK;
 

--- a/ports/nrf/hal/hal_twi.h
+++ b/ports/nrf/hal/hal_twi.h
@@ -47,7 +47,7 @@ typedef enum
 {
     HAL_TWI_ERROR_NONE  = 0x00,                     /* No error */
     HAL_TWI_ERROR_ORE   = TWI_ERRORSRC_OVERRUN_Msk, /* Overrun error. A new byte was received before previous
-                                                        byte got read by software from the RXD register. (Previous data is lost). */
+                                                       byte got read by software from the RXD register. (Previous data is lost). */
     HAL_TWI_ERROR_ANACK = TWI_ERRORSRC_ANACK_Msk,   /* NACK received after sending the address. */
     HAL_TWI_ERROR_DNACK = TWI_ERRORSRC_DNACK_Msk,   /* NACK received after sending a data byte (write '1' to clear). */
 } hal_twi_error_t;

--- a/ports/nrf/hal/hal_twi.h
+++ b/ports/nrf/hal/hal_twi.h
@@ -109,13 +109,13 @@ void hal_twi_master_init(NRF_TWI_Type * p_instance, hal_twi_init_t const * p_twi
 
 hal_twi_error_t hal_twi_master_tx(NRF_TWI_Type  * p_instance,
                                   uint8_t         addr,
-                                  uint16_t        transfer_size,
+                                  size_t          transfer_size,
                                   const uint8_t * tx_data,
                                   bool            stop);
 
 hal_twi_error_t hal_twi_master_rx(NRF_TWI_Type  * p_instance,
                                   uint8_t         addr,
-                                  uint16_t        transfer_size,
+                                  size_t          transfer_size,
                                   uint8_t       * rx_data,
                                   bool            stop);
 

--- a/ports/nrf/hal/hal_twi.h
+++ b/ports/nrf/hal/hal_twi.h
@@ -45,10 +45,11 @@
 
 typedef enum
 {
-    HAL_TWI_ERROR_NONE      = 0x00,    /* No error */
-    HAL_TWI_ERROR_ORE       = 0x01,    /* Overrun error. A new byte was received before previous byte got read by software from the RXD register. (Previous data is lost). */
-    HAL_TWI_ERROR_ANACK     = 0x02,    /* NACK received after sending the address. */
-    HAL_TWI_ERROR_DNACK     = 0x04,    /* NACK received after sending a data byte (write '1' to clear). */
+    HAL_TWI_ERROR_NONE  = 0x00,                     /* No error */
+    HAL_TWI_ERROR_ORE   = TWI_ERRORSRC_OVERRUN_Msk, /* Overrun error. A new byte was received before previous
+                                                        byte got read by software from the RXD register. (Previous data is lost). */
+    HAL_TWI_ERROR_ANACK = TWI_ERRORSRC_ANACK_Msk,   /* NACK received after sending the address. */
+    HAL_TWI_ERROR_DNACK = TWI_ERRORSRC_DNACK_Msk,   /* NACK received after sending a data byte (write '1' to clear). */
 } hal_twi_error_t;
 
 

--- a/ports/nrf/hal/hal_twi.h
+++ b/ports/nrf/hal/hal_twi.h
@@ -41,8 +41,16 @@
 
 #define TWI_IRQ_VALUES (const uint32_t[]){SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn, \
                                           SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn}
-
 #endif
+
+typedef enum
+{
+    HAL_TWI_ERROR_NONE      = 0x00,    /* No error */
+    HAL_TWI_ERROR_ORE       = 0x01,    /* Overrun error. A new byte was received before previous byte got read by software from the RXD register. (Previous data is lost). */
+    HAL_TWI_ERROR_ANACK     = 0x02,    /* NACK received after sending the address. */
+    HAL_TWI_ERROR_DNACK     = 0x04,    /* NACK received after sending a data byte (write '1' to clear). */
+} hal_twi_error_t;
+
 
 #if NRF52
 
@@ -99,17 +107,17 @@ typedef struct __TWI_HandleTypeDef
 
 void hal_twi_master_init(NRF_TWI_Type * p_instance, hal_twi_init_t const * p_twi_init);
 
-void hal_twi_master_tx(NRF_TWI_Type  * p_instance,
-                       uint8_t         addr,
-                       uint16_t        transfer_size,
-                       const uint8_t * tx_data,
-                       bool            stop);
+hal_twi_error_t hal_twi_master_tx(NRF_TWI_Type  * p_instance,
+                                  uint8_t         addr,
+                                  uint16_t        transfer_size,
+                                  const uint8_t * tx_data,
+                                  bool            stop);
 
-void hal_twi_master_rx(NRF_TWI_Type  * p_instance,
-                       uint8_t         addr,
-                       uint16_t        transfer_size,
-                       uint8_t       * rx_data,
-                       bool            stop);
+hal_twi_error_t hal_twi_master_rx(NRF_TWI_Type  * p_instance,
+                                  uint8_t         addr,
+                                  uint16_t        transfer_size,
+                                  uint8_t       * rx_data,
+                                  bool            stop);
 
 
 void hal_twi_slave_init(NRF_TWI_Type * p_instance, hal_twi_init_t const * p_twi_init);

--- a/ports/nrf/modules/machine/i2c.c
+++ b/ports/nrf/modules/machine/i2c.c
@@ -30,6 +30,7 @@
 #include "py/nlr.h"
 #include "py/runtime.h"
 #include "py/mphal.h"
+#include "py/mperrno.h"
 #include "extmod/machine_i2c.h"
 #include "i2c.h"
 #include "hal_twi.h"
@@ -133,7 +134,11 @@ int machine_hard_i2c_readfrom(mp_obj_base_t *self_in, uint16_t addr, uint8_t *de
 
     hal_twi_error_t err_code = hal_twi_master_rx(self->i2c->instance, addr, len, dest, stop);
 
-    return err_code;
+    if (err_code != HAL_TWI_ERROR_NONE) {
+        return -MP_EIO;
+    }
+
+    return len;
 }
 
 int machine_hard_i2c_writeto(mp_obj_base_t *self_in, uint16_t addr, const uint8_t *src, size_t len, bool stop) {
@@ -141,7 +146,11 @@ int machine_hard_i2c_writeto(mp_obj_base_t *self_in, uint16_t addr, const uint8_
 
     hal_twi_error_t err_code = hal_twi_master_tx(self->i2c->instance, addr, len, src, stop);
 
-    return err_code;
+    if (err_code != HAL_TWI_ERROR_NONE) {
+        return -MP_EIO;
+    }
+
+    return len;
 }
 
 STATIC const mp_machine_i2c_p_t machine_hard_i2c_p = {

--- a/ports/nrf/modules/machine/i2c.c
+++ b/ports/nrf/modules/machine/i2c.c
@@ -128,22 +128,20 @@ mp_obj_t machine_hard_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
     return MP_OBJ_FROM_PTR(self);
 }
 
-#include <stdio.h>
-
 int machine_hard_i2c_readfrom(mp_obj_base_t *self_in, uint16_t addr, uint8_t *dest, size_t len, bool stop) {
     machine_hard_i2c_obj_t *self = (machine_hard_i2c_obj_t *)self_in;
 
-    hal_twi_master_rx(self->i2c->instance, addr, len, dest, stop);
+    hal_twi_error_t err_code = hal_twi_master_rx(self->i2c->instance, addr, len, dest, stop);
 
-    return 0;
+    return err_code;
 }
 
 int machine_hard_i2c_writeto(mp_obj_base_t *self_in, uint16_t addr, const uint8_t *src, size_t len, bool stop) {
     machine_hard_i2c_obj_t *self = (machine_hard_i2c_obj_t *)self_in;
 
-    hal_twi_master_tx(self->i2c->instance, addr, len, src, stop);
+    hal_twi_error_t err_code = hal_twi_master_tx(self->i2c->instance, addr, len, src, stop);
 
-    return 0;
+    return err_code;
 }
 
 STATIC const mp_machine_i2c_p_t machine_hard_i2c_p = {


### PR DESCRIPTION
This patch also makes i2c.scan() method work properly.