### PR TITLE
nrf/boards/common.ld: Avoid overflowing the .text region.

### DIFF
--- a/ports/nrf/boards/common.ld
+++ b/ports/nrf/boards/common.ld
@@ -32,13 +32,13 @@ SECTIONS
     */
         
     /* used by the startup to initialize data */
-    _sidata = .;
+    _sidata = LOADADDR(.data);
         
     /* This is the initialized data section
     The program executes knowing that the data is in the RAM
     but the loader puts the initial values in the FLASH (inidata).
     It is one task of the startup to copy the initial values from FLASH to RAM. */
-    .data : AT (_sidata)
+    .data :
     {
         . = ALIGN(4);
         _sdata = .;        /* create a global symbol at data start; used by startup code in order to initialise the .data section in RAM */
@@ -48,7 +48,7 @@ SECTIONS
 
         . = ALIGN(4);
         _edata = .;        /* define a global symbol at data end; used by startup code in order to initialise the .data section in RAM */
-    } >RAM 
+    } >RAM AT>FLASH_TEXT
             
     /* Uninitialized data section */
     .bss :


### PR DESCRIPTION
Similar commit to this one:
https://github.com/tralamazza/micropython/commit/6e56e6269f467e59316b5e4cb04ea37ab6a0dfe3

When .text + .data oveflow available flash, the linker may not show an
error. This change makes sure .data is included in the size calculation.

For some background, see the excellent [Red Had documentation](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/4/html/Using_ld_the_GNU_Linker/sections.html#OUTPUT-SECTION-LMA), in particular this one:

> The linker will normally set the LMA equal to the VMA. You can change that by using the `AT` keyword. The expression lma that follows the `AT` keyword specifies the load address of the section. Alternatively, with `AT>lma_region` expression, you may specify a memory region for the section's load address.

In other words, using just the load address (`AT(load_address)`) we can set the initial pointer from where to write (with no limit), while the `AT>lma_region` actually places the data in a section limiting it's size. At least, that's how I understand it and from what I remember from DFU development this fixed an issue where the linker would silently succeed but would write just outside of the specified memory area causing weird issues. After this fix, the linker gave an error, as it should.