### PR TITLE
nrf/drivers/ble_drv: Fixing sd_ble_enable bug for SD s132 v.2.0.1

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -196,7 +196,7 @@ uint32_t ble_drv_stack_enable(void) {
 
 #if (BLUETOOTH_SD == 132)
     uint32_t app_ram_start = 0x200039c0;
-#if (BLE_API_VERSION == 3)
+#if (BLE_API_VERSION == 2) || (BLE_API_VERSION == 3)
     err_code = sd_ble_enable(&ble_enable_params, &app_ram_start); // 8K SD headroom from linker script.
 #elif (BLE_API_VERSION >= 4)
     err_code = sd_ble_enable(&app_ram_start); // 8K SD headroom from linker script.


### PR DESCRIPTION
Feather52 target which is using SD s132 v.2.0.1 cannot compile
due to variable containing RAM start address is not used.

This patch enables the correct sd_ble_enable variant for this SD.

Tested using ublupy advertisment.