### PR TITLE
nrf: Fix stack size setting in linker scripts.

### DIFF
--- a/ports/nrf/boards/common.ld
+++ b/ports/nrf/boards/common.ld
@@ -77,7 +77,7 @@ SECTIONS
     .stack :
     {
         . = ALIGN(4);
-        . = . + _minimum_stack_size;
+        . = . + _stack_size;
         . = ALIGN(4);
     } >RAM
 
@@ -93,6 +93,11 @@ SECTIONS
 
     .ARM.attributes 0 : { *(.ARM.attributes) }
 }
+
+/* Define heap and stack areas */
+_ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+_heap_end = _ram_end - _stack_size;
 
 _flash_user_start = ORIGIN(FLASH_USER);
 _flash_user_end   = ORIGIN(FLASH_USER) + LENGTH(FLASH_USER);

--- a/ports/nrf/boards/feather52/custom_nrf52832_dfu_app.ld
+++ b/ports/nrf/boards/feather52/custom_nrf52832_dfu_app.ld
@@ -14,16 +14,7 @@ MEMORY
 }
  
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
+_stack_size = 8K;
 _minimum_heap_size = 16K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20007000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/microbit/custom_nrf51822_s110_microbit.ld
+++ b/ports/nrf/boards/microbit/custom_nrf51822_s110_microbit.ld
@@ -13,16 +13,7 @@ MEMORY
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
+_stack_size = 2K;
 _minimum_heap_size = 1K;
-
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20003c00; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf51x22_256k_16k.ld
+++ b/ports/nrf/boards/nrf51x22_256k_16k.ld
@@ -13,16 +13,7 @@ MEMORY
 }
  
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 4K;
+_stack_size = 4K;
 _minimum_heap_size = 8K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20002000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf51x22_256k_16k_s110_8.0.0.ld
+++ b/ports/nrf/boards/nrf51x22_256k_16k_s110_8.0.0.ld
@@ -13,16 +13,7 @@ MEMORY
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
-_minimum_heap_size = 1K;
-
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20003c00; /* tunable */
+_stack_size = 2K;
+_minimum_heap_size = 4K;
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf51x22_256k_32k.ld
+++ b/ports/nrf/boards/nrf51x22_256k_32k.ld
@@ -13,16 +13,7 @@ MEMORY
 }
  
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 4K;
+_stack_size = 4K;
 _minimum_heap_size = 24K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20006000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf51x22_256k_32k_s110_8.0.0.ld
+++ b/ports/nrf/boards/nrf51x22_256k_32k_s110_8.0.0.ld
@@ -13,16 +13,7 @@ MEMORY
 }
  
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
+_stack_size = 4K;
 _minimum_heap_size = 1K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20005000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf51x22_256k_32k_s120_2.1.0.ld
+++ b/ports/nrf/boards/nrf51x22_256k_32k_s120_2.1.0.ld
@@ -13,16 +13,7 @@ MEMORY
 }
  
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
+_stack_size = 4K;
 _minimum_heap_size = 4K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20003000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf51x22_256k_32k_s130_2.0.1.ld
+++ b/ports/nrf/boards/nrf51x22_256k_32k_s130_2.0.1.ld
@@ -13,16 +13,7 @@ MEMORY
 }
  
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
+_stack_size = 4K;
 _minimum_heap_size = 6K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20002000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf52832_512k_64k.ld
+++ b/ports/nrf/boards/nrf52832_512k_64k.ld
@@ -12,16 +12,7 @@ MEMORY
 }
  
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
+_stack_size = 8K;
 _minimum_heap_size = 32K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20008000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf52832_512k_64k_s132_2.0.1.ld
+++ b/ports/nrf/boards/nrf52832_512k_64k_s132_2.0.1.ld
@@ -12,16 +12,7 @@ MEMORY
 }
  
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
+_stack_size = 8K;
 _minimum_heap_size = 16K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20007000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf52832_512k_64k_s132_3.0.0.ld
+++ b/ports/nrf/boards/nrf52832_512k_64k_s132_3.0.0.ld
@@ -12,16 +12,7 @@ MEMORY
 }
  
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
+_stack_size = 8K;
 _minimum_heap_size = 16K;
- 
-/* top end of the stack */
-
-/*_stack_end = ORIGIN(RAM) + LENGTH(RAM);*/
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-/* RAM extents for the garbage collector */
-_ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20007000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf52832_512k_64k_s132_5.0.0.ld
+++ b/ports/nrf/boards/nrf52832_512k_64k_s132_5.0.0.ld
@@ -12,7 +12,7 @@ MEMORY
 }
  
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 2K;
+_stack_size = 8K;
 _minimum_heap_size = 16K;
  
 /* top end of the stack */
@@ -22,6 +22,5 @@ _estack = ORIGIN(RAM) + LENGTH(RAM);
 
 /* RAM extents for the garbage collector */
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20007000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/boards/nrf52840_1M_256k.ld
+++ b/ports/nrf/boards/nrf52840_1M_256k.ld
@@ -12,7 +12,7 @@ MEMORY
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */
-_minimum_stack_size = 40K;
+_stack_size = 8K;
 _minimum_heap_size = 128K;
  
 /* top end of the stack */
@@ -22,6 +22,5 @@ _estack = ORIGIN(RAM) + LENGTH(RAM);
 
 /* RAM extents for the garbage collector */
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = 0x20020000; /* tunable */
 
 INCLUDE "boards/common.ld"

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -43,7 +43,7 @@
 #define MICROPY_READER_VFS          (MICROPY_VFS)
 #define MICROPY_ENABLE_GC           (1)
 #define MICROPY_ENABLE_FINALISER    (1)
-#define MICROPY_STACK_CHECK         (0)
+#define MICROPY_STACK_CHECK         (1)
 #define MICROPY_HELPER_REPL         (1)
 #define MICROPY_REPL_EMACS_KEYS     (0)
 #define MICROPY_REPL_AUTO_INDENT    (1)


### PR DESCRIPTION
The nrf51x22_256k_16k_s110_8.0.0.ld had a stack size of only 1kB, which is way too low. Additionally, the indicated `_minimum_stack_size` (set at 2kB for that chip) isn't respected in any way.

This commit sets the heap end to the given stack size (in kilobytes), making it much easier to configure.

----

Somewhat related: should we enable `MICROPY_STACK_CHECK` by default? It is a protection against stack overflows, which are especially easy to hit on these low memory devices and are very hard to debug.