### PR TITLE
nrf: Make LTO configurable via Makefile flag.

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -71,6 +71,13 @@ CFLAGS_MCU_m4 = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4 -mfpu=fpv4-s
 
 CFLAGS_MCU_m0 = $(CFLAGS_CORTEX_M) --short-enums -mtune=cortex-m0 -mcpu=cortex-m0 -mfloat-abi=soft -fno-builtin
 
+LTO ?= 1
+ifeq ($(LTO),1)
+CFLAGS_LTO += -flto
+else
+CFLAGS_LTO += -Wl,--gc-sections -ffunction-sections -fdata-sections
+endif
+
 
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES)) 
 CFLAGS += $(INC) -Wall -Werror -ansi -std=gnu99 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD)
@@ -78,7 +85,7 @@ CFLAGS += -fno-strict-aliasing
 CFLAGS += -fstack-usage
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'
-CFLAGS += -flto
+CFLAGS += $(CFLAGS_LTO)
 
 LDFLAGS = $(CFLAGS)
 LDFLAGS += -Xlinker -Map=$(@:.elf=.map)


### PR DESCRIPTION
LTO messes up debuggability and may cause some other issues.
Additionally, it does not always result in reduced code size.

LTO is also much slower for many small builds (where only a few files change).