### PR TITLE
nrf: Improve include of boardmodules.mk

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -26,9 +26,7 @@ else
 	include drivers/bluetooth/bluetooth_common.mk
 endif
 
-ifeq ($(shell test -e boards/$(BOARD)/modules/boardmodules.mk && echo -n yes),yes)
-	include boards/$(BOARD)/modules/boardmodules.mk
-endif
+-include boards/$(BOARD)/modules/boardmodules.mk
 
 # qstr definitions (must come before including py.mk)
 QSTR_DEFS = qstrdefsport.h $(BUILD)/pins_qstr.h


### PR DESCRIPTION
Removing shell commands for checking if boardmodules.mk exists
under boards/<BOARD>/modules folder before including it.

This patch does the equivalent to previous test without using
shell commands. Hence, including the .mk if it exists.

Reference:
https://stackoverflow.com/questions/8346118/check-if-a-makefile-exists-before-including-it