### PR TITLE
nrf/boards/microbit/modules: Initialize variable in microbit_sleep function

### DIFF
--- a/ports/nrf/boards/microbit/modules/modmicrobit.c
+++ b/ports/nrf/boards/microbit/modules/modmicrobit.c
@@ -43,7 +43,7 @@ STATIC mp_obj_t microbit_reset_(void) {
 MP_DEFINE_CONST_FUN_OBJ_0(microbit_reset_obj, microbit_reset_);
 
 STATIC mp_obj_t microbit_sleep(mp_obj_t ms_in) {
-    mp_int_t ms;
+    mp_int_t ms = 0;
     if (mp_obj_is_integer(ms_in)) {
         ms = mp_obj_get_int(ms_in);
 #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT


### PR DESCRIPTION

When compiling microbit with LTO=0, compiler error occurs due to
ms variable in microbit_sleep might not be initialized.

This patch initialize the variable to 0.