### PR TITLE
nrf: Move linker-defined symbols to where they are used.

### DIFF
--- a/ports/nrf/gccollect.c
+++ b/ports/nrf/gccollect.c
@@ -31,6 +31,8 @@
 #include "py/gc.h"
 #include "gccollect.h"
 
+extern uint32_t _ram_end;
+
 static inline uintptr_t get_sp(void) {
     uintptr_t result;
     __asm__ ("mov %0, sp\n" : "=r" (result) );

--- a/ports/nrf/gccollect.h
+++ b/ports/nrf/gccollect.h
@@ -28,18 +28,6 @@
 #ifndef GC_COLLECT_H__
 #define GC_COLLECT_H__
 
-extern uint32_t _etext;
-extern uint32_t _sidata;
-extern uint32_t _ram_start;
-extern uint32_t _sdata;
-extern uint32_t _edata;
-extern uint32_t _sbss;
-extern uint32_t _ebss;
-extern uint32_t _heap_start;
-extern uint32_t _heap_end;
-extern uint32_t _estack;
-extern uint32_t _ram_end;
-
 void gc_collect(void);
 
 #endif

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -40,7 +40,6 @@
 #include "py/compile.h"
 #include "lib/utils/pyexec.h"
 #include "readline.h"
-#include "gccollect.h"
 #include "modmachine.h"
 #include "modmusic.h"
 #include "modules/uos/microbitfs.h"
@@ -92,6 +91,7 @@ void do_str(const char *src, mp_parse_input_kind_t input_kind) {
 
 extern uint32_t _heap_start;
 extern uint32_t _heap_end;
+extern uint32_t _ram_end;
 
 int main(int argc, char **argv) {
     

--- a/ports/nrf/modules/machine/modmachine.c
+++ b/ports/nrf/modules/machine/modmachine.c
@@ -36,7 +36,6 @@
 #include "lib/utils/pyexec.h"
 #include "lib/oofatfs/ff.h"
 #include "lib/oofatfs/diskio.h"
-#include "gccollect.h"
 #include "pin.h"
 #include "uart.h"
 #include "spi.h"
@@ -63,6 +62,18 @@
 #define PYB_RESET_LPCOMP    (17)
 #define PYB_RESET_DIF       (18)
 #define PYB_RESET_NFC       (19)
+
+extern uint32_t _etext;
+extern uint32_t _sidata;
+extern uint32_t _ram_start;
+extern uint32_t _sdata;
+extern uint32_t _edata;
+extern uint32_t _sbss;
+extern uint32_t _ebss;
+extern uint32_t _heap_start;
+extern uint32_t _heap_end;
+extern uint32_t _estack;
+extern uint32_t _ram_end;
 
 STATIC uint32_t reset_cause;
 


### PR DESCRIPTION
`gccollect.h` is not the right place to define them.

This change does not affect firmware size, and probably doesn't change the firmware at all.