### PR TITLE
nrf: Fix NUS console when using boot.py or main.py.

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_uart.c
+++ b/ports/nrf/drivers/bluetooth/ble_uart.c
@@ -97,6 +97,9 @@ static ubluepy_advertise_data_t m_adv_data_eddystone_url;
 #endif // BLUETOOTH_WEBBLUETOOTH_REPL
 
 int mp_hal_stdin_rx_chr(void) {
+    while (!ble_uart_enabled()) {
+        // wait for connection
+    }
     while (isBufferEmpty(mp_rx_ring_buffer)) {
         ;
     }
@@ -107,6 +110,9 @@ int mp_hal_stdin_rx_chr(void) {
 }
 
 void mp_hal_stdout_tx_strn(const char *str, size_t len) {
+    // Not connected: drop output
+    if (!ble_uart_enabled()) return;
+
     uint8_t *buf = (uint8_t *)str;
     size_t send_len;
 
@@ -142,6 +148,7 @@ STATIC void gap_event_handler(mp_obj_t self_in, uint16_t event_id, uint16_t conn
     } else if (event_id == 17) {         // disconnect event
         self->conn_handle = 0xFFFF;      // invalid connection handle
         m_connected = false;
+        m_cccd_enabled = false;
         ble_uart_advertise();
     }
 }
@@ -158,6 +165,8 @@ STATIC void gatts_event_handler(mp_obj_t self_in, uint16_t event_id, uint16_t at
                 #if MICROPY_KBD_EXCEPTION
                 if (data[i] == mp_interrupt_char) {
                     mp_keyboard_interrupt();
+                    m_rx_ring_buffer.start = 0;
+                    m_rx_ring_buffer.end = 0;
                 } else
                 #endif
                 {

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -195,25 +195,12 @@ pin_init0();
            MP_PARSE_FILE_INPUT);
 #endif
 
-#if MICROPY_VFS || MICROPY_HW_HAS_BUILTIN_FLASH
-    // run boot.py and main.py if they exist.
-    if (mp_import_stat("boot.py") == MP_IMPORT_STAT_FILE) {
-        pyexec_file("boot.py");
-    }
-    if (mp_import_stat("main.py") == MP_IMPORT_STAT_FILE) {
-        pyexec_file("main.py");
-    }
-#endif
-
     // Main script is finished, so now go into REPL mode.
     // The REPL mode can change, or it can request a soft reset.
     int ret_code = 0;
 
 #if MICROPY_PY_BLE_NUS
     ble_uart_init0();
-    while (!ble_uart_enabled()) {
-        ;
-    }
 #endif
 
 #if MICROPY_PY_MACHINE_SOFT_PWM
@@ -231,6 +218,16 @@ pin_init0();
 #if MICROPY_PY_MACHINE_SOFT_PWM
     ticker_start();
     pwm_start();
+#endif
+
+#if MICROPY_VFS || MICROPY_HW_HAS_BUILTIN_FLASH
+    // run boot.py and main.py if they exist.
+    if (mp_import_stat("boot.py") == MP_IMPORT_STAT_FILE) {
+        pyexec_file("boot.py");
+    }
+    if (mp_import_stat("main.py") == MP_IMPORT_STAT_FILE) {
+        pyexec_file("main.py");
+    }
 #endif
 
     for (;;) {


### PR DESCRIPTION
Costs 28 bytes of .text when NUS is enabled, but makes sure `boot.py` and `main.py` are usable in combination with NUS (that is, they start executing on reset instead of waiting for a connection).

Disadvantage: all initial console output is lost. But then again, there wouldn't be any console output to show without this patch as it just waits.