### PR TITLE
nrf/modules/random: Rename port config for RNG

### DIFF
--- a/ports/nrf/boards/arduino_primo/mpconfigboard.h
+++ b/ports/nrf/boards/arduino_primo/mpconfigboard.h
@@ -39,6 +39,7 @@
 #define MICROPY_PY_MACHINE_I2C      (1)
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/boards/dvk_bl652/mpconfigboard.h
+++ b/ports/nrf/boards/dvk_bl652/mpconfigboard.h
@@ -38,6 +38,7 @@
 #define MICROPY_PY_MACHINE_I2C      (1)
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/boards/feather52/mpconfigboard.h
+++ b/ports/nrf/boards/feather52/mpconfigboard.h
@@ -38,6 +38,7 @@
 #define MICROPY_PY_MACHINE_I2C      (1)
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/boards/microbit/mpconfigboard.h
+++ b/ports/nrf/boards/microbit/mpconfigboard.h
@@ -39,7 +39,7 @@
 #define MICROPY_PY_MACHINE_I2C      (1)
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
-#define MICROPY_PY_HW_RNG           (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (0)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/boards/pca10000/mpconfigboard.h
+++ b/ports/nrf/boards/pca10000/mpconfigboard.h
@@ -37,6 +37,7 @@
 #define MICROPY_PY_MACHINE_I2C      (0)
 #define MICROPY_PY_MACHINE_ADC      (0)
 #define MICROPY_PY_MACHINE_TEMP     (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/boards/pca10001/mpconfigboard.h
+++ b/ports/nrf/boards/pca10001/mpconfigboard.h
@@ -37,6 +37,7 @@
 #define MICROPY_PY_MACHINE_I2C      (1)
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/boards/pca10028/mpconfigboard.h
+++ b/ports/nrf/boards/pca10028/mpconfigboard.h
@@ -37,6 +37,7 @@
 #define MICROPY_PY_MACHINE_I2C      (1)
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/boards/pca10031/mpconfigboard.h
+++ b/ports/nrf/boards/pca10031/mpconfigboard.h
@@ -37,6 +37,7 @@
 #define MICROPY_PY_MACHINE_I2C      (1)
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/boards/pca10040/mpconfigboard.h
+++ b/ports/nrf/boards/pca10040/mpconfigboard.h
@@ -38,7 +38,7 @@
 #define MICROPY_PY_MACHINE_I2C      (1)
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
-#define MICROPY_PY_HW_RNG           (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/boards/pca10056/mpconfigboard.h
+++ b/ports/nrf/boards/pca10056/mpconfigboard.h
@@ -38,6 +38,7 @@
 #define MICROPY_PY_MACHINE_I2C      (1)
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (1)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/boards/wt51822_s4at/mpconfigboard.h
+++ b/ports/nrf/boards/wt51822_s4at/mpconfigboard.h
@@ -39,6 +39,7 @@
 #define MICROPY_PY_MACHINE_I2C      (1)
 #define MICROPY_PY_MACHINE_ADC      (1)
 #define MICROPY_PY_MACHINE_TEMP     (1)
+#define MICROPY_PY_RANDOM_HW_RNG    (1)
 
 #define MICROPY_HW_HAS_LED          (0)
 #define MICROPY_HW_HAS_SWITCH       (0)

--- a/ports/nrf/modules/random/modrandom.c
+++ b/ports/nrf/modules/random/modrandom.c
@@ -29,6 +29,9 @@
 #include <string.h>
 
 #include "py/runtime.h"
+
+#if MICROPY_PY_RANDOM_HW_RNG
+
 #include "nrf_rng.h"
 #include "modrandom.h"
 
@@ -37,8 +40,6 @@
 #include "ble_drv.h"
 #define BLUETOOTH_STACK_ENABLED() (ble_drv_stack_enabled())
 #endif
-
-#if MICROPY_PY_HW_RNG
 
 static inline uint32_t generate_hw_random(void) {
     uint32_t retval = 0;
@@ -219,4 +220,4 @@ const mp_obj_module_t random_module = {
     .globals = (mp_obj_dict_t*)&mp_module_random_globals,
 };
 
-#endif // MICROPY_PY_HW_RNG
+#endif // MICROPY_PY_RANDOM_HW_RNG

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -169,8 +169,8 @@
 #define MICROPY_PY_MACHINE_RTCOUNTER (0)
 #endif
 
-#ifndef MICROPY_PY_HW_RNG
-#define MICROPY_PY_HW_RNG           (1)
+#ifndef MICROPY_PY_RANDOM_HW_RNG
+#define MICROPY_PY_RANDOM_HW_RNG    (0)
 #endif
 
 
@@ -227,8 +227,8 @@ extern const struct _mp_obj_module_t random_module;
 #define MUSIC_MODULE
 #endif
 
-#if MICROPY_PY_HW_RNG
-#define RANDOM_MODULE                        { MP_ROM_QSTR(MP_QSTR_random), MP_ROM_PTR(&random_module) },
+#if MICROPY_PY_RANDOM_HW_RNG
+#define RANDOM_MODULE                       { MP_ROM_QSTR(MP_QSTR_random), MP_ROM_PTR(&random_module) },
 #else
 #define RANDOM_MODULE
 #endif


### PR DESCRIPTION
Renaming config for enabling random module with hw
random number generator from MICROPY_PY_HW_RNG to
MICROPY_PY_RANDOM_HW_RNG to indicate which module it
is configuring.

Also, disabling the config by default in mpconfigport.h.

Adding the enable of RNG in all board configs.

Moving ifdef in modrandom, which test for the config being
set, earlier in the code. This is to prevent un-necessary
includes if not needed.