### PR TITLE
nrf/modules: Align method to resolve pin object

### DIFF
--- a/ports/nrf/modules/machine/pwm.c
+++ b/ports/nrf/modules/machine/pwm.c
@@ -237,8 +237,7 @@ STATIC mp_obj_t machine_hard_pwm_make_new(mp_arg_val_t *args) {
 
     // check if PWM pin is set
     if (args[ARG_pin].u_obj != MP_OBJ_NULL) {
-        pin_obj_t *pin_obj = args[ARG_pin].u_obj;
-        self->p_config->pwm_pin = pin_obj->pin;
+        self->p_config->pwm_pin = mp_hal_get_pin_obj(args[ARG_pin].u_obj)->pin;
     } else {
         // TODO: raise exception.
     }

--- a/ports/nrf/modules/machine/spi.c
+++ b/ports/nrf/modules/machine/spi.c
@@ -285,9 +285,9 @@ STATIC mp_obj_t machine_hard_spi_make_new(mp_arg_val_t *args) {
         && args[ARG_NEW_mosi].u_obj != MP_OBJ_NULL
         && args[ARG_NEW_miso].u_obj != MP_OBJ_NULL) {
 
-        self->p_config->sck_pin  = ((const pin_obj_t *)args[ARG_NEW_sck].u_obj)->pin;
-        self->p_config->mosi_pin = ((const pin_obj_t *)args[ARG_NEW_mosi].u_obj)->pin;
-        self->p_config->miso_pin = ((const pin_obj_t *)args[ARG_NEW_miso].u_obj)->pin;
+        self->p_config->sck_pin  = mp_hal_get_pin_obj(args[ARG_NEW_sck].u_obj)->pin;
+        self->p_config->mosi_pin = mp_hal_get_pin_obj(args[ARG_NEW_mosi].u_obj)->pin;
+        self->p_config->miso_pin = mp_hal_get_pin_obj(args[ARG_NEW_miso].u_obj)->pin;
     } else {
         self->p_config->sck_pin  = MICROPY_HW_SPI0_SCK;
         self->p_config->mosi_pin = MICROPY_HW_SPI0_MOSI;

--- a/ports/nrf/modules/music/modmusic.c
+++ b/ports/nrf/modules/music/modmusic.c
@@ -282,7 +282,7 @@ STATIC mp_obj_t microbit_music_stop(mp_uint_t n_args, const mp_obj_t *args) {
     const pin_obj_t *pin;
     if (n_args == 0) {
 #ifdef MICROPY_HW_MUSIC_PIN
-        pin = pin_find(MP_OBJ_NEW_SMALL_INT(MICROPY_HW_MUSIC_PIN));
+        pin = mp_hal_get_pin_obj(MP_OBJ_NEW_SMALL_INT(MICROPY_HW_MUSIC_PIN));
 #else
         mp_raise_ValueError("pin parameter not given");
 #endif
@@ -335,7 +335,7 @@ STATIC mp_obj_t microbit_music_play(mp_uint_t n_args, const mp_obj_t *pos_args, 
     const pin_obj_t *pin;
     if (args[1].u_obj == MP_OBJ_NULL) {
 #ifdef MICROPY_HW_MUSIC_PIN
-        pin = pin_find(MP_OBJ_NEW_SMALL_INT(MICROPY_HW_MUSIC_PIN));
+        pin = mp_hal_get_pin_obj(MP_OBJ_NEW_SMALL_INT(MICROPY_HW_MUSIC_PIN));
 #else
         mp_raise_ValueError("pin parameter not given");
 #endif
@@ -390,7 +390,7 @@ STATIC mp_obj_t microbit_music_pitch(mp_uint_t n_args, const mp_obj_t *pos_args,
     const pin_obj_t *pin;
     if (args[2].u_obj == MP_OBJ_NULL) {
 #ifdef MICROPY_HW_MUSIC_PIN
-        pin = pin_find(MP_OBJ_NEW_SMALL_INT(MICROPY_HW_MUSIC_PIN));
+        pin = mp_hal_get_pin_obj(MP_OBJ_NEW_SMALL_INT(MICROPY_HW_MUSIC_PIN));
 #else
         mp_raise_ValueError("pin parameter not given");
 #endif


### PR DESCRIPTION
machine/i2c already uses mp_hal_get_pin_obj which
points to pin_find function in order to locate correct
pin object to use.

The pin_find function was recently updated to also
being able to locate pins based on an integer value,
such that pin number can be used as argument to object
constructors.

This patch modfies and uniforms pin object lookup for
SPI, music and pwm.