### PR TITLE
nrf: Return immediatly from mp_hal_delay_us if 0us is given

### DIFF
--- a/ports/nrf/mphalport.c
+++ b/ports/nrf/mphalport.c
@@ -82,6 +82,10 @@ void mp_hal_stdout_tx_str(const char *str) {
 
 void mp_hal_delay_us(mp_uint_t us)
 {
+    if (us == 0) {
+        return;
+    }
+
     register uint32_t delay __ASM ("r0") = us;
     __ASM volatile (
 #ifdef NRF51


### PR DESCRIPTION
After nrfx 1.0.0 a new macro was introduced to do a common
hardware timeout. The macro function triggers a counter of
retries or a timeout in us. However, in many cases, like in
nrfx_adc.c the timeout value is set to 0, leading to a infinite
loop in mp_hal_delay_us. This patch prevents this from happening.

Path of error:
nrfx_adc.c -> NRFX_WAIT_FOR -> NRFX_DELAY_US -> mp_hal_delay_us.