### PR TITLE
nrf: Add support for reading output pin state

### DIFF
--- a/ports/nrf/mphalport.h
+++ b/ports/nrf/mphalport.h
@@ -64,7 +64,7 @@ const char * nrfx_error_code_lookup(uint32_t err_code);
 #define mp_hal_get_pin_obj(o)    pin_find(o)
 #define mp_hal_pin_high(p)       nrf_gpio_pin_set(p->pin)
 #define mp_hal_pin_low(p)        nrf_gpio_pin_clear(p->pin)
-#define mp_hal_pin_read(p)       nrf_gpio_pin_read(p->pin)
+#define mp_hal_pin_read(p)       (nrf_gpio_pin_dir_get(p->pin) == NRF_GPIO_PIN_DIR_OUTPUT) ? nrf_gpio_pin_out_read(p->pin) : nrf_gpio_pin_read(p->pin)
 #define mp_hal_pin_write(p, v)   do { if (v) { mp_hal_pin_high(p); } else { mp_hal_pin_low(p); } } while (0)
 #define mp_hal_pin_od_low(p)     mp_hal_pin_low(p)
 #define mp_hal_pin_od_high(p)    mp_hal_pin_high(p)


### PR DESCRIPTION
Current adoption on top of nrfx only reads the GPIO->IN register.
In order to read back an output state, nrf_gpio_pin_out_read has
to be called.

This patch concatinate the two read functions such that, if
either IN or OUT register has a value 1 it will return this,
else 0.

Updating lib/nrfx submodule to latest version of master to get
the new GPIO API to read pin direction.
(nrfx: d37b16f2b894b0928395f6f56ca741287a31a244)