### PR TITLE
Clang compatibility

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -93,9 +93,10 @@ CFLAGS_MCU_m0 = $(CFLAGS_CORTEX_M) -fshort-enums -mtune=cortex-m0 -mcpu=cortex-m
 
 LTO ?= 1
 ifeq ($(LTO),1)
-CFLAGS_LTO += -flto
+CFLAGS += -flto
 else
-CFLAGS_LTO += -Wl,--gc-sections -ffunction-sections -fdata-sections
+CFLAGS += -ffunction-sections -fdata-sections
+LDFLAGS += -Wl,--gc-sections
 endif
 
 
@@ -104,7 +105,6 @@ CFLAGS += $(INC) -Wall -Werror -g -ansi -std=c11 -nostdlib $(COPT) $(NRF_DEFINES
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'
-CFLAGS += $(CFLAGS_LTO)
 
 LDFLAGS = $(CFLAGS)
 LDFLAGS += -Xlinker -Map=$(@:.elf=.map)

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -102,7 +102,6 @@ endif
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES)) 
 CFLAGS += $(INC) -Wall -Werror -g -ansi -std=gnu99 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD)
 CFLAGS += -fno-strict-aliasing
-CFLAGS += -fstack-usage
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'
 CFLAGS += $(CFLAGS_LTO)

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -89,7 +89,7 @@ CFLAGS_CORTEX_M = -mthumb -mabi=aapcs -fsingle-precision-constant -Wdouble-promo
 
 CFLAGS_MCU_m4 = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
 
-CFLAGS_MCU_m0 = $(CFLAGS_CORTEX_M) --short-enums -mtune=cortex-m0 -mcpu=cortex-m0 -mfloat-abi=soft -fno-builtin
+CFLAGS_MCU_m0 = $(CFLAGS_CORTEX_M) -fshort-enums -mtune=cortex-m0 -mcpu=cortex-m0 -mfloat-abi=soft -fno-builtin
 
 LTO ?= 1
 ifeq ($(LTO),1)

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -100,7 +100,7 @@ endif
 
 
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES)) 
-CFLAGS += $(INC) -Wall -Werror -g -ansi -std=gnu99 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD)
+CFLAGS += $(INC) -Wall -Werror -g -ansi -std=c11 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_MOD)
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -Iboards/$(BOARD)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'

--- a/ports/nrf/modules/machine/adc.c
+++ b/ports/nrf/modules/machine/adc.c
@@ -97,7 +97,7 @@ STATIC int adc_find(mp_obj_t id) {
     int adc_idx = adc_id;
 
     if (adc_idx >= 0 && adc_idx <= MP_ARRAY_SIZE(machine_adc_obj)
-        && machine_adc_obj[adc_idx].id != -1) {
+        && machine_adc_obj[adc_idx].id != (uint8_t)-1) {
         return adc_idx;
     }
     nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError,

--- a/ports/nrf/modules/uos/microbitfs.c
+++ b/ports/nrf/modules/uos/microbitfs.c
@@ -27,7 +27,6 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <errno.h>
 #include <sys/stat.h>
 
 #include "microbitfs.h"

--- a/ports/nrf/mphalport.c
+++ b/ports/nrf/mphalport.c
@@ -24,7 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include <errno.h>
 #include <string.h>
 
 #include "py/mpstate.h"

--- a/ports/nrf/mphalport.c
+++ b/ports/nrf/mphalport.c
@@ -153,9 +153,6 @@ void mp_hal_delay_us(mp_uint_t us)
         " NOP\n"
 #endif
         " BNE 1b\n"
-#ifdef NRF51
-        ".syntax divided\n"
-#endif
         : "+r" (delay));
 }
 


### PR DESCRIPTION
Some commits to bring somewhat more Clang compatibility (but not complete support).

Note that some commits change the output. At least the `-std=c11` change (why??) and one later change but I haven't investigated which.

Tested quickly, the REPL still appears to work.