### PR TITLE
fix adc config

### DIFF
--- a/ports/nrf/modules/machine/adc.c
+++ b/ports/nrf/modules/machine/adc.c
@@ -155,7 +155,6 @@ int16_t machine_adc_value_read(machine_adc_obj_t * adc_obj) {
 
     nrfx_adc_channel_t channel_config = {
         .config.resolution = NRF_ADC_CONFIG_RES_8BIT,
-        .config.input      = NRF_ADC_CONFIG_SCALING_INPUT_TWO_THIRDS,
         .config.reference  = NRF_ADC_CONFIG_REF_VBG,
         .config.input      = adc_obj->ain,
         .config.extref     = ADC_CONFIG_EXTREFSEL_None << ADC_CONFIG_EXTREFSEL_Pos // Currently not defined in nrfx/hal.
@@ -229,7 +228,6 @@ mp_obj_t machine_adc_battery_level(void) {
 
     nrfx_adc_channel_t channel_config = {
         .config.resolution = NRF_ADC_CONFIG_RES_8BIT,
-        .config.input      = NRF_ADC_CONFIG_SCALING_SUPPLY_ONE_THIRD,
         .config.reference  = NRF_ADC_CONFIG_REF_VBG,
         .config.input      = NRF_ADC_CONFIG_INPUT_DISABLED,
         .config.extref     = ADC_CONFIG_EXTREFSEL_None << ADC_CONFIG_EXTREFSEL_Pos // Currently not defined in nrfx/hal.


### PR DESCRIPTION
It is an error to define it twice, but I'm not sure which of the two is the correct one.

Untested. Found with Clang compatibility testing.