### PR TITLE
nrf: Enable micro:bit FS by default 

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -906,7 +906,7 @@ void ble_drv_discover_descriptors(void) {
 
 static void sd_evt_handler(uint32_t evt_id) {
     switch (evt_id) {
-#if MICROPY_HW_HAS_BUILTIN_FLASH
+#if MICROPY_MBFS
         case NRF_EVT_FLASH_OPERATION_SUCCESS:
             flash_operation_finished(FLASH_STATE_SUCCESS);
             break;

--- a/ports/nrf/drivers/flash.c
+++ b/ports/nrf/drivers/flash.c
@@ -26,7 +26,7 @@
 
 #include "py/mpconfig.h"
 
-#if MICROPY_HW_HAS_BUILTIN_FLASH && BLUETOOTH_SD
+#if MICROPY_MBFS && BLUETOOTH_SD
 
 #include "drivers/flash.h"
 #include "drivers/bluetooth/ble_drv.h"
@@ -129,4 +129,4 @@ void flash_write_bytes(uint32_t dst, const uint8_t *src, uint32_t num_bytes) {
     }
 }
 
-#endif // MICROPY_HW_HAS_BUILTIN_FLASH
+#endif // MICROPY_MBFS

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -155,7 +155,7 @@ soft_reset:
 
 pin_init0();
 
-#if MICROPY_HW_HAS_BUILTIN_FLASH
+#if MICROPY_MBFS
     microbit_filesystem_init();
 #endif
 
@@ -225,7 +225,7 @@ pin_init0();
     pwm_start();
 #endif
 
-#if MICROPY_VFS || MICROPY_HW_HAS_BUILTIN_FLASH
+#if MICROPY_VFS || MICROPY_MBFS
     // run boot.py and main.py if they exist.
     if (mp_import_stat("boot.py") == MP_IMPORT_STAT_FILE) {
         pyexec_file("boot.py");
@@ -262,7 +262,7 @@ pin_init0();
 }
 
 #if !MICROPY_VFS
-#if MICROPY_HW_HAS_BUILTIN_FLASH
+#if MICROPY_MBFS
 // Use micro:bit filesystem
 mp_lexer_t *mp_lexer_new_from_file(const char *filename) {
     return uos_mbfs_new_reader(filename);

--- a/ports/nrf/modules/uos/microbitfs.c
+++ b/ports/nrf/modules/uos/microbitfs.c
@@ -39,7 +39,7 @@
 #include "extmod/vfs.h"
 #include "mpconfigport.h"
 
-#if MICROPY_HW_HAS_BUILTIN_FLASH
+#if MICROPY_MBFS
 
 #define DEBUG_FILE 0
 #if DEBUG_FILE
@@ -701,4 +701,4 @@ STATIC mp_obj_t uos_mbfs_stat(mp_obj_t filename) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(uos_mbfs_stat_obj, uos_mbfs_stat);
 
-#endif // MICROPY_HW_HAS_BUILTIN_FLASH
+#endif // MICROPY_MBFS

--- a/ports/nrf/modules/uos/moduos.c
+++ b/ports/nrf/modules/uos/moduos.c
@@ -152,7 +152,7 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_sync), MP_ROM_PTR(&mod_os_sync_obj) },
 
-#elif MICROPY_HW_HAS_BUILTIN_FLASH
+#elif MICROPY_MBFS
     { MP_ROM_QSTR(MP_QSTR_listdir), MP_ROM_PTR(&uos_mbfs_listdir_obj) },
     { MP_ROM_QSTR(MP_QSTR_ilistdir), MP_ROM_PTR(&uos_mbfs_ilistdir_obj) }, // uses ~136 bytes
     { MP_ROM_QSTR(MP_QSTR_stat), MP_ROM_PTR(&uos_mbfs_stat_obj) },         // uses ~228 bytes

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -81,6 +81,11 @@
 #define mp_builtin_open_obj mp_vfs_open_obj
 #endif
 
+// Enable micro:bit filesystem by default.
+#ifndef MICROPY_MBFS
+#define MICROPY_MBFS (1)
+#endif
+
 #define MICROPY_STREAMS_NON_BLOCK   (1)
 #define MICROPY_MODULE_WEAK_LINKS   (1)
 #define MICROPY_CAN_OVERRIDE_BUILTINS (1)


### PR DESCRIPTION
Update configuration define from
MICROPY_HW_HAS_BUILTIN_FLASH to MICROPY_MBFS.

MICROPY_MBFS will enable the builtin flash as
part of enabling the micro:bit FS.