### PR TITLE
nrf/modules/machine/spi: Move enable-guard to prevent wrong includes

### DIFF
--- a/ports/nrf/modules/machine/spi.c
+++ b/ports/nrf/modules/machine/spi.c
@@ -29,8 +29,11 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "py/nlr.h"
 #include "py/runtime.h"
+
+#if MICROPY_PY_MACHINE_HW_SPI
+
+#include "py/nlr.h"
 #include "py/mphal.h"
 #include "extmod/machine_spi.h"
 #include "pin.h"
@@ -41,8 +44,6 @@
 #else
 #include "nrfx_spim.h"
 #endif
-
-#if MICROPY_PY_MACHINE_HW_SPI
 
 /// \moduleref pyb
 /// \class SPI - a master-driven serial protocol


### PR DESCRIPTION
This patch moves the check of SPI configuration before
including any SPI header files. As targets might disable SPI
support, current code ends up in including SPIM if not SPI
is configured. Hence, this is why the check whether the module is
enabled should be done before including headers.