### PR TITLE
nrf/boards/feather52: Move phony targets to main Makefile

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -248,6 +248,23 @@ $(filter $(PY_BUILD)/../extmod/vfs_fat_%.o, $(PY_O)): COPT += -Os
 
 .PHONY: all flash sd binary hex
 
+ifeq ($(BOARD),feather52)
+.PHONY: dfu-gen dfu-flash
+check_defined = \
+    $(strip $(foreach 1,$1, \
+    $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+    $(error Undefined make flag: $1$(if $2, ($2))))
+
+dfu-gen:
+	nrfutil dfu genpkg --dev-type 0x0052 --application $(BUILD)/$(OUTPUT_FILENAME).hex $(BUILD)/dfu-package.zip
+
+dfu-flash:
+	@:$(call check_defined, SERIAL, example: SERIAL=/dev/ttyUSB0)
+	sudo nrfutil dfu serial --package $(BUILD)/dfu-package.zip -p $(SERIAL)
+endif
+
 all: binary hex
 
 OUTPUT_FILENAME = firmware

--- a/ports/nrf/boards/feather52/mpconfigboard.mk
+++ b/ports/nrf/boards/feather52/mpconfigboard.mk
@@ -7,19 +7,3 @@ LD_FILE = boards/feather52/custom_nrf52832_dfu_app.ld
 
 NRF_DEFINES += -DNRF52832_XXAA
 
-
-check_defined = \
-    $(strip $(foreach 1,$1, \
-    $(call __check_defined,$1,$(strip $(value 2)))))
-__check_defined = \
-    $(if $(value $1),, \
-    $(error Undefined make flag: $1$(if $2, ($2))))
-
-.PHONY: dfu-gen dfu-flash
-
-dfu-gen:
-	nrfutil dfu genpkg --dev-type 0x0052 --application $(BUILD)/$(OUTPUT_FILENAME).hex $(BUILD)/dfu-package.zip
-
-dfu-flash:
-	@:$(call check_defined, SERIAL, example: SERIAL=/dev/ttyUSB0)
-	sudo nrfutil dfu serial --package $(BUILD)/dfu-package.zip -p $(SERIAL)


### PR DESCRIPTION
dfu-gen .PHONY target is run unconditionally as first build
target when included, and might fail if the hex file is not
yet generated.

To prevent this, the dfu-gen and dfu-flash targets are moved
to the main Makefile and only exposed if feather52 is the
defined BOARD.