### PR TITLE
nrf: Move pyb module to boards module

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -57,6 +57,7 @@ INC += -I./modules/ubluepy
 INC += -I./modules/music
 INC += -I./modules/random
 INC += -I./modules/ble
+INC += -I./modules/board
 INC += -I../../lib/mp-readline
 INC += -I./drivers/bluetooth
 INC += -I./drivers
@@ -203,12 +204,12 @@ DRIVERS_SRC_C += $(addprefix modules/,\
 	machine/timer.c \
 	machine/rtcounter.c \
 	machine/pwm.c \
-	machine/led.c \
 	machine/temp.c \
 	uos/moduos.c \
 	uos/microbitfs.c \
 	utime/modutime.c \
-	pyb/modpyb.c \
+	board/modboard.c \
+	board/led.c \
 	ubluepy/modubluepy.c \
 	ubluepy/ubluepy_peripheral.c \
 	ubluepy/ubluepy_service.c \

--- a/ports/nrf/examples/ubluepy_temp.py
+++ b/ports/nrf/examples/ubluepy_temp.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE
 
-from pyb import LED
+from board import LED
 from machine import RTCounter, Temp
 from ubluepy import Service, Characteristic, UUID, Peripheral, constants
 

--- a/ports/nrf/help.c
+++ b/ports/nrf/help.c
@@ -4,7 +4,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2013, 2014 Damien P. George
- * Copyright (c) 2016 Glenn Ruben Bakke
+ * Copyright (c) 2016 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,7 @@ const char nrf5_help_text[] =
 "\n"
 "Quick overview of commands for the board:\n"
 #if MICROPY_HW_HAS_LED
-"  pyb.LED(n)    -- create an LED object for LED n (n=" HELP_TEXT_BOARD_LED ")\n"
+"  board.LED(n)    -- create an LED object for LED n (n=" HELP_TEXT_BOARD_LED ")\n"
 "\n"
 #endif
 #if BLUETOOTH_SD

--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -149,7 +149,7 @@ soft_reset:
             MP_OBJ_NEW_SMALL_INT(0),
             MP_OBJ_NEW_SMALL_INT(115200),
         };
-        MP_STATE_PORT(pyb_stdio_uart) = machine_hard_uart_type.make_new((mp_obj_t)&machine_hard_uart_type, MP_ARRAY_SIZE(args), 0, args);
+        MP_STATE_PORT(board_stdio_uart) = machine_hard_uart_type.make_new((mp_obj_t)&machine_hard_uart_type, MP_ARRAY_SIZE(args), 0, args);
     }
 #endif
 
@@ -195,8 +195,8 @@ pin_init0();
 #if (MICROPY_HW_HAS_LED)
     led_init();
 
-    do_str("import pyb\r\n" \
-           "pyb.LED(1).on()",
+    do_str("import board\r\n" \
+           "board.LED(1).on()",
            MP_PARSE_FILE_INPUT);
 #endif
 

--- a/ports/nrf/modules/board/led.c
+++ b/ports/nrf/modules/board/led.c
@@ -4,7 +4,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2013-2016 Damien P. George
- * Copyright (c) 2015 Glenn Ruben Bakke
+ * Copyright (c) 2015 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,41 +36,41 @@
 #define LED_OFF(pin) {(MICROPY_HW_LED_PULLUP) ? nrf_gpio_pin_set(pin) : nrf_gpio_pin_clear(pin); }
 #define LED_ON(pin) {(MICROPY_HW_LED_PULLUP) ? nrf_gpio_pin_clear(pin) : nrf_gpio_pin_set(pin); }
 
-typedef struct _pyb_led_obj_t {
+typedef struct _board_led_obj_t {
     mp_obj_base_t base;
     mp_uint_t led_id;
     mp_uint_t hw_pin;
     uint8_t hw_pin_port;
-} pyb_led_obj_t;
+} board_led_obj_t;
 
-STATIC const pyb_led_obj_t pyb_led_obj[] = {
+STATIC const board_led_obj_t board_led_obj[] = {
 #if MICROPY_HW_LED_TRICOLOR
-    {{&pyb_led_type}, PYB_LED_RED, MICROPY_HW_LED_RED},
-    {{&pyb_led_type}, PYB_LED_GREEN, MICROPY_HW_LED_GREEN},
-    {{&pyb_led_type}, PYB_LED_BLUE, MICROPY_HW_LED_BLUE},
+    {{&board_led_type}, BOARD_LED_RED, MICROPY_HW_LED_RED},
+    {{&board_led_type}, BOARD_LED_GREEN, MICROPY_HW_LED_GREEN},
+    {{&board_led_type}, BOARD_LED_BLUE, MICROPY_HW_LED_BLUE},
 #elif (MICROPY_HW_LED_COUNT == 1)
-    {{&pyb_led_type}, PYB_LED1, MICROPY_HW_LED1},
+    {{&board_led_type}, BOARD_LED1, MICROPY_HW_LED1},
 #elif (MICROPY_HW_LED_COUNT == 2)
-    {{&pyb_led_type}, PYB_LED1, MICROPY_HW_LED1},
-    {{&pyb_led_type}, PYB_LED2, MICROPY_HW_LED2},
+    {{&board_led_type}, BOARD_LED1, MICROPY_HW_LED1},
+    {{&board_led_type}, BOARD_LED2, MICROPY_HW_LED2},
 #else
-    {{&pyb_led_type}, PYB_LED1, MICROPY_HW_LED1},
-    {{&pyb_led_type}, PYB_LED2, MICROPY_HW_LED2},
-    {{&pyb_led_type}, PYB_LED3, MICROPY_HW_LED3},
-    {{&pyb_led_type}, PYB_LED4, MICROPY_HW_LED4},
+    {{&board_led_type}, BOARD_LED1, MICROPY_HW_LED1},
+    {{&board_led_type}, BOARD_LED2, MICROPY_HW_LED2},
+    {{&board_led_type}, BOARD_LED3, MICROPY_HW_LED3},
+    {{&board_led_type}, BOARD_LED4, MICROPY_HW_LED4},
 #endif
 };
 
-#define NUM_LEDS MP_ARRAY_SIZE(pyb_led_obj)
+#define NUM_LEDS MP_ARRAY_SIZE(board_led_obj)
 
 void led_init(void) {
     for (uint8_t i = 0; i < NUM_LEDS; i++) {
-        LED_OFF(pyb_led_obj[i].hw_pin);
-        nrf_gpio_cfg_output(pyb_led_obj[i].hw_pin);
+        LED_OFF(board_led_obj[i].hw_pin);
+        nrf_gpio_cfg_output(board_led_obj[i].hw_pin);
     }
 }
 
-void led_state(pyb_led_obj_t * led_obj, int state) {
+void led_state(board_led_obj_t * led_obj, int state) {
     if (state == 1) {
         LED_ON(led_obj->hw_pin);
     } else {
@@ -78,7 +78,7 @@ void led_state(pyb_led_obj_t * led_obj, int state) {
     }
 }
 
-void led_toggle(pyb_led_obj_t * led_obj) {
+void led_toggle(board_led_obj_t * led_obj) {
     nrf_gpio_pin_toggle(led_obj->hw_pin);
 }
 
@@ -88,7 +88,7 @@ void led_toggle(pyb_led_obj_t * led_obj) {
 /* MicroPython bindings                                                      */
 
 void led_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    pyb_led_obj_t *self = self_in;
+    board_led_obj_t *self = self_in;
     mp_printf(print, "LED(%lu)", self->led_id);
 }
 
@@ -109,13 +109,13 @@ STATIC mp_obj_t led_obj_make_new(const mp_obj_type_t *type, size_t n_args, size_
     }
 
     // return static led object
-    return (mp_obj_t)&pyb_led_obj[led_id - 1];
+    return (mp_obj_t)&board_led_obj[led_id - 1];
 }
 
 /// \method on()
 /// Turn the LED on.
 mp_obj_t led_obj_on(mp_obj_t self_in) {
-    pyb_led_obj_t *self = self_in;
+    board_led_obj_t *self = self_in;
     led_state(self, 1);
     return mp_const_none;
 }
@@ -123,7 +123,7 @@ mp_obj_t led_obj_on(mp_obj_t self_in) {
 /// \method off()
 /// Turn the LED off.
 mp_obj_t led_obj_off(mp_obj_t self_in) {
-    pyb_led_obj_t *self = self_in;
+    board_led_obj_t *self = self_in;
     led_state(self, 0);
     return mp_const_none;
 }
@@ -131,7 +131,7 @@ mp_obj_t led_obj_off(mp_obj_t self_in) {
 /// \method toggle()
 /// Toggle the LED between on and off.
 mp_obj_t led_obj_toggle(mp_obj_t self_in) {
-    pyb_led_obj_t *self = self_in;
+    board_led_obj_t *self = self_in;
     led_toggle(self);
     return mp_const_none;
 }
@@ -148,7 +148,7 @@ STATIC const mp_rom_map_elem_t led_locals_dict_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(led_locals_dict, led_locals_dict_table);
 
-const mp_obj_type_t pyb_led_type = {
+const mp_obj_type_t board_led_type = {
     { &mp_type_type },
     .name = MP_QSTR_LED,
     .print = led_obj_print,

--- a/ports/nrf/modules/board/led.h
+++ b/ports/nrf/modules/board/led.h
@@ -3,7 +3,8 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Glenn Ruben Bakke
+ * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2015 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,32 +25,29 @@
  * THE SOFTWARE.
  */
 
-#include "py/builtin.h"
-#include "lib/utils/pyexec.h"
-#include "py/runtime.h"
-#include "py/obj.h"
-#include "led.h"
-#include "nrf.h" // TODO: figure out where to put this import
-#include "pin.h"
+#ifndef LED_H
+#define LED_H
 
-#if MICROPY_HW_HAS_LED
-#define PYB_LED_MODULE { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&pyb_led_type) },
+typedef enum {
+#if MICROPY_HW_LED_TRICOLOR
+    BOARD_LED_RED = 1,
+    BOARD_LED_GREEN = 2,
+    BOARD_LED_BLUE = 3
+#elif (MICROPY_HW_LED_COUNT == 1)
+    BOARD_LED1 = 1,
+#elif (MICROPY_HW_LED_COUNT == 2)
+    BOARD_LED1 = 1,
+    BOARD_LED2 = 2,
 #else
-#define PYB_LED_MODULE
+    BOARD_LED1 = 1,
+    BOARD_LED2 = 2,
+    BOARD_LED3 = 3,
+    BOARD_LED4 = 4
 #endif
+} board_led_t;
 
-STATIC const mp_rom_map_elem_t pyb_module_globals_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_pyb) },
-    { MP_ROM_QSTR(MP_QSTR_repl_info), MP_ROM_PTR(&pyb_set_repl_info_obj) },
-    { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&pin_type) },
-    PYB_LED_MODULE
-/*    { MP_ROM_QSTR(MP_QSTR_main), MP_ROM_PTR(&pyb_main_obj) }*/
-};
+void led_init(void);
 
+extern const mp_obj_type_t board_led_type;
 
-STATIC MP_DEFINE_CONST_DICT(pyb_module_globals, pyb_module_globals_table);
-
-const mp_obj_module_t pyb_module = {
-    .base = { &mp_type_module },
-    .globals = (mp_obj_dict_t*)&pyb_module_globals,
-};
+#endif // LED_H

--- a/ports/nrf/modules/board/modboard.c
+++ b/ports/nrf/modules/board/modboard.c
@@ -3,8 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2013, 2014 Damien P. George
- * Copyright (c) 2015 Glenn Ruben Bakke
+ * Copyright (c) 2015 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,29 +24,30 @@
  * THE SOFTWARE.
  */
 
-#ifndef LED_H
-#define LED_H
+#include "py/builtin.h"
+#include "lib/utils/pyexec.h"
+#include "py/runtime.h"
+#include "py/obj.h"
+#include "led.h"
+#include "nrf.h" // TODO: figure out where to put this import
+#include "pin.h"
 
-typedef enum {
-#if MICROPY_HW_LED_TRICOLOR
-    PYB_LED_RED = 1,
-    PYB_LED_GREEN = 2,
-    PYB_LED_BLUE = 3
-#elif (MICROPY_HW_LED_COUNT == 1)
-    PYB_LED1 = 1,
-#elif (MICROPY_HW_LED_COUNT == 2)
-    PYB_LED1 = 1,
-    PYB_LED2 = 2,
+#if MICROPY_HW_HAS_LED
+#define PYB_LED_MODULE { MP_ROM_QSTR(MP_QSTR_LED), MP_ROM_PTR(&board_led_type) },
 #else
-    PYB_LED1 = 1,
-    PYB_LED2 = 2,
-    PYB_LED3 = 3,
-    PYB_LED4 = 4
+#define PYB_LED_MODULE
 #endif
-} pyb_led_t;
 
-void led_init(void);
+STATIC const mp_rom_map_elem_t board_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_board) },
+    { MP_ROM_QSTR(MP_QSTR_repl_info), MP_ROM_PTR(&pyb_set_repl_info_obj) },
+    PYB_LED_MODULE
+};
 
-extern const mp_obj_type_t pyb_led_type;
 
-#endif // LED_H
+STATIC MP_DEFINE_CONST_DICT(board_module_globals, board_module_globals_table);
+
+const mp_obj_module_t board_module = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&board_module_globals,
+};

--- a/ports/nrf/modules/machine/modmachine.c
+++ b/ports/nrf/modules/machine/modmachine.c
@@ -136,7 +136,7 @@ STATIC mp_obj_t machine_info(mp_uint_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_info_obj, 0, 1, machine_info);
 
-// Resets the pyboard in a manner similar to pushing the external RESET button.
+// Resets the board in a manner similar to pushing the external RESET button.
 STATIC mp_obj_t machine_reset(void) {
     NVIC_SystemReset();
     return mp_const_none;
@@ -176,7 +176,7 @@ STATIC mp_obj_t machine_enable_irq(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(machine_enable_irq_obj, machine_enable_irq);
 
-// Resets the pyboard in a manner similar to pushing the external RESET button.
+// Resets the board in a manner similar to pushing the external RESET button.
 STATIC mp_obj_t machine_disable_irq(void) {
 #ifndef BLUETOOTH_SD
     __disable_irq();
@@ -195,7 +195,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_enable_irq),         MP_ROM_PTR(&machine_enable_irq_obj) },
     { MP_ROM_QSTR(MP_QSTR_disable_irq),        MP_ROM_PTR(&machine_disable_irq_obj) },
 #if MICROPY_HW_ENABLE_RNG
-    { MP_ROM_QSTR(MP_QSTR_rng),                MP_ROM_PTR(&pyb_rng_get_obj) },
+    { MP_ROM_QSTR(MP_QSTR_rng),                MP_ROM_PTR(&random_module) },
 #endif
     { MP_ROM_QSTR(MP_QSTR_sleep),              MP_ROM_PTR(&machine_sleep_obj) },
     { MP_ROM_QSTR(MP_QSTR_deepsleep),          MP_ROM_PTR(&machine_deepsleep_obj) },

--- a/ports/nrf/modules/machine/pin.c
+++ b/ports/nrf/modules/machine/pin.c
@@ -40,7 +40,7 @@
 extern const pin_obj_t machine_pin_obj[];
 extern const uint8_t machine_pin_num_of_pins;
 
-/// \moduleref pyb
+/// \moduleref machine
 /// \class Pin - control I/O pins
 ///
 /// A pin is the basic object to control I/O pins.  It has methods to set
@@ -49,40 +49,40 @@ extern const uint8_t machine_pin_num_of_pins;
 ///
 /// Usage Model:
 ///
-/// All Board Pins are predefined as pyb.Pin.board.Name
+/// All Board Pins are predefined as machine.Pin.board.Name
 ///
-///     x1_pin = pyb.Pin.board.X1
+///     x1_pin = machine.Pin.board.X1
 ///
-///     g = pyb.Pin(pyb.Pin.board.X1, pyb.Pin.IN)
+///     g = machine.Pin(machine.Pin.board.X1, machine.Pin.IN)
 ///
 /// CPU pins which correspond to the board pins are available
-/// as `pyb.cpu.Name`. For the CPU pins, the names are the port letter
-/// followed by the pin number. On the PYBv1.0, `pyb.Pin.board.X1` and
-/// `pyb.Pin.cpu.B6` are the same pin.
+/// as `machine.cpu.Name`. For the CPU pins, the names are the port letter
+/// followed by the pin number. On the PYBv1.0, `machine.Pin.board.X1` and
+/// `machine.Pin.cpu.B6` are the same pin.
 ///
 /// You can also use strings:
 ///
-///     g = pyb.Pin('X1', pyb.Pin.OUT_PP)
+///     g = machine.Pin('X1', machine.Pin.OUT)
 ///
 /// Users can add their own names:
 ///
-///     MyMapperDict = { 'LeftMotorDir' : pyb.Pin.cpu.C12 }
-///     pyb.Pin.dict(MyMapperDict)
-///     g = pyb.Pin("LeftMotorDir", pyb.Pin.OUT_OD)
+///     MyMapperDict = { 'LeftMotorDir' : machine.Pin.cpu.C12 }
+///     machine.Pin.dict(MyMapperDict)
+///     g = machine.Pin("LeftMotorDir", machine.Pin.OUT)
 ///
 /// and can query mappings
 ///
-///     pin = pyb.Pin("LeftMotorDir")
+///     pin = machine.Pin("LeftMotorDir")
 ///
 /// Users can also add their own mapping function:
 ///
 ///     def MyMapper(pin_name):
 ///        if pin_name == "LeftMotorDir":
-///            return pyb.Pin.cpu.A0
+///            return machine.Pin.cpu.A0
 ///
-///     pyb.Pin.mapper(MyMapper)
+///     machine.Pin.mapper(MyMapper)
 ///
-/// So, if you were to call: `pyb.Pin("LeftMotorDir", pyb.Pin.OUT_PP)`
+/// So, if you were to call: `machine.Pin("LeftMotorDir", machine.Pin.OUT)`
 /// then `"LeftMotorDir"` is passed directly to the mapper function.
 ///
 /// To summarise, the following order determines how things get mapped into
@@ -94,7 +94,7 @@ extern const uint8_t machine_pin_num_of_pins;
 /// 4. Supply a string which matches a board pin
 /// 5. Supply a string which matches a CPU port/pin
 ///
-/// You can set `pyb.Pin.debug(True)` to get some debug information about
+/// You can set `machine.Pin.debug(True)` to get some debug information about
 /// how a particular object gets mapped to a pin.
 
 #define PIN_DEBUG (0)
@@ -639,7 +639,7 @@ const mp_obj_type_t pin_type = {
     .locals_dict = (mp_obj_dict_t*)&pin_locals_dict,
 };
 
-/// \moduleref pyb
+/// \moduleref machine
 /// \class PinAF - Pin Alternate Functions
 ///
 /// A Pin represents a physical pin on the microcprocessor. Each pin
@@ -648,7 +648,7 @@ const mp_obj_type_t pin_type = {
 ///
 /// Usage Model:
 ///
-///     x3 = pyb.Pin.board.X3
+///     x3 = machine.Pin.board.X3
 ///     x3_af = x3.af_list()
 ///
 /// x3_af will now contain an array of PinAF objects which are availble on
@@ -662,9 +662,9 @@ const mp_obj_type_t pin_type = {
 /// is desired.
 ///
 /// To configure X3 to expose TIM2_CH3, you could use:
-///    pin = pyb.Pin(pyb.Pin.board.X3, mode=pyb.Pin.AF_PP, af=pyb.Pin.AF1_TIM2)
+///    pin = machine.Pin(machine.Pin.board.X3, mode=machine.Pin.AF_PP, af=machine.Pin.AF1_TIM2)
 /// or:
-///    pin = pyb.Pin(pyb.Pin.board.X3, mode=pyb.Pin.AF_PP, af=1)
+///    pin = machine.Pin(machine.Pin.board.X3, mode=machine.Pin.AF_PP, af=1)
 
 /// \method __str__()
 /// Return a string describing the alternate function.

--- a/ports/nrf/modules/machine/spi.c
+++ b/ports/nrf/modules/machine/spi.c
@@ -45,7 +45,7 @@
 #include "nrfx_spim.h"
 #endif
 
-/// \moduleref pyb
+/// \moduleref machine
 /// \class SPI - a master-driven serial protocol
 ///
 /// SPI is a serial protocol that is driven by a master.  At the physical level
@@ -54,7 +54,7 @@
 /// See usage model of I2C; SPI is very similar.  Main difference is
 /// parameters to init the SPI bus:
 ///
-///     from pyb import SPI
+///     from machine import SPI
 ///     spi = SPI(1, SPI.MASTER, baudrate=600000, polarity=1, phase=0, crc=0x7)
 ///
 /// Only required parameter is mode, SPI.MASTER or SPI.SLAVE.  Polarity can be

--- a/ports/nrf/modules/machine/uart.h
+++ b/ports/nrf/modules/machine/uart.h
@@ -4,7 +4,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2013, 2014 Damien P. George
- * Copyright (c) 2015 Glenn Ruben Bakke
+ * Copyright (c) 2015 - 2018 Glenn Ruben Bakke
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,11 +30,6 @@
 
 #include "pin.h"
 #include "genhdr/pins.h"
-
-typedef enum {
-    PYB_UART_NONE = 0,
-    PYB_UART_1 = 1,
-} pyb_uart_t;
 
 typedef struct _machine_hard_uart_obj_t machine_hard_uart_obj_t;
 extern const mp_obj_type_t machine_hard_uart_type;

--- a/ports/nrf/modules/ubluepy/modubluepy.h
+++ b/ports/nrf/modules/ubluepy/modubluepy.h
@@ -38,7 +38,7 @@ p.advertise(device_name="MicroPython")
 DB setup:
 
 from ubluepy import Service, Characteristic, UUID, Peripheral, constants
-from pyb import LED
+from board import LED
 
 def event_handler(id, handle, data):
     print("BLE event:", id, "handle:", handle)

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -212,7 +212,7 @@ typedef unsigned int mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 // extra built in modules to add to the list of known ones
-extern const struct _mp_obj_module_t pyb_module;
+extern const struct _mp_obj_module_t board_module;
 extern const struct _mp_obj_module_t machine_module;
 extern const struct _mp_obj_module_t mp_module_utime;
 extern const struct _mp_obj_module_t mp_module_uos;
@@ -255,7 +255,7 @@ extern const struct _mp_obj_module_t ble_module;
 #endif
 
 #define MICROPY_PORT_BUILTIN_MODULES \
-    { MP_ROM_QSTR(MP_QSTR_pyb), MP_ROM_PTR(&pyb_module) }, \
+    { MP_ROM_QSTR(MP_QSTR_board), MP_ROM_PTR(&board_module) }, \
     { MP_ROM_QSTR(MP_QSTR_machine), MP_ROM_PTR(&machine_module) }, \
     { MP_ROM_QSTR(MP_QSTR_utime), MP_ROM_PTR(&mp_module_utime) }, \
     { MP_ROM_QSTR(MP_QSTR_time), MP_ROM_PTR(&mp_module_utime) }, \
@@ -270,7 +270,7 @@ extern const struct _mp_obj_module_t ble_module;
 #else
 extern const struct _mp_obj_module_t ble_module;
 #define MICROPY_PORT_BUILTIN_MODULES \
-    { MP_ROM_QSTR(MP_QSTR_pyb), MP_ROM_PTR(&pyb_module) }, \
+    { MP_ROM_QSTR(MP_QSTR_board), MP_ROM_PTR(&board_module) }, \
     { MP_ROM_QSTR(MP_QSTR_machine), MP_ROM_PTR(&machine_module) }, \
     { MP_ROM_QSTR(MP_QSTR_utime), MP_ROM_PTR(&mp_module_utime) }, \
     { MP_ROM_QSTR(MP_QSTR_uos), MP_ROM_PTR(&mp_module_uos) }, \
@@ -292,7 +292,7 @@ extern const struct _mp_obj_module_t ble_module;
 
 // extra constants
 #define MICROPY_PORT_CONSTANTS \
-    { MP_ROM_QSTR(MP_QSTR_pyb), MP_ROM_PTR(&pyb_module) }, \
+    { MP_ROM_QSTR(MP_QSTR_board), MP_ROM_PTR(&board_module) }, \
     { MP_ROM_QSTR(MP_QSTR_machine), MP_ROM_PTR(&machine_module) }, \
     BLE_MODULE \
 
@@ -326,7 +326,7 @@ extern const struct _mp_obj_module_t ble_module;
     mp_obj_t pin_irq_handlers[NUM_OF_PINS]; \
     \
     /* stdio is repeated on this UART object if it's not null */ \
-    struct _machine_hard_uart_obj_t *pyb_stdio_uart; \
+    struct _machine_hard_uart_obj_t *board_stdio_uart; \
     \
     ROOT_POINTERS_MUSIC \
     ROOT_POINTERS_SOFTPWM \

--- a/ports/nrf/mphalport.c
+++ b/ports/nrf/mphalport.c
@@ -54,8 +54,8 @@ void mp_hal_set_interrupt_char(int c) {
 #if !MICROPY_PY_BLE_NUS
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
-        if (MP_STATE_PORT(pyb_stdio_uart) != NULL && uart_rx_any(MP_STATE_PORT(pyb_stdio_uart))) {
-            return uart_rx_char(MP_STATE_PORT(pyb_stdio_uart));
+        if (MP_STATE_PORT(board_stdio_uart) != NULL && uart_rx_any(MP_STATE_PORT(board_stdio_uart))) {
+            return uart_rx_char(MP_STATE_PORT(board_stdio_uart));
         }
     }
 
@@ -63,14 +63,14 @@ int mp_hal_stdin_rx_chr(void) {
 }
 
 void mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
-    if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
-        uart_tx_strn(MP_STATE_PORT(pyb_stdio_uart), str, len);
+    if (MP_STATE_PORT(board_stdio_uart) != NULL) {
+        uart_tx_strn(MP_STATE_PORT(board_stdio_uart), str, len);
     }
 }
 
 void mp_hal_stdout_tx_strn_cooked(const char *str, mp_uint_t len) {
-    if (MP_STATE_PORT(pyb_stdio_uart) != NULL) {
-        uart_tx_strn_cooked(MP_STATE_PORT(pyb_stdio_uart), str, len);
+    if (MP_STATE_PORT(board_stdio_uart) != NULL) {
+        uart_tx_strn_cooked(MP_STATE_PORT(board_stdio_uart), str, len);
     }
 }
 #endif


### PR DESCRIPTION
Cleaning up use of "pyb" module.
Moving the file to a new folder and updating the
makefile accordingly. New module created called
"board" to take over the functionality of the legacy
"pyb" module.

Updating outdated documentation referring to pyb.Pin,
to now point to machine.Pin.