### PR TITLE
nrf/boards: Use 3kB stack in the s110 linker script.

### DIFF
--- a/ports/nrf/boards/s110_8.0.0.ld
+++ b/ports/nrf/boards/s110_8.0.0.ld
@@ -5,5 +5,5 @@ _sd_size = 0x00018000;
 _sd_ram  = 0x00002000;
 _fs_size = DEFINED(_fs_size) ? _fs_size : 20K;
 
-_stack_size = _ram_size > 16K ? 4K : 2K;
-_minimum_heap_size = 4K;
+_stack_size = _ram_size > 16K ? 4K : 3K;
+_minimum_heap_size = 3K;


### PR DESCRIPTION
For me, 2kB is not enough and I have enough heap.

Let me know whether you think this should be changed in general.