### PR TITLE
nrf/boards: Check for stack/heap size using an assert.

### DIFF
--- a/ports/nrf/boards/common.ld
+++ b/ports/nrf/boards/common.ld
@@ -63,24 +63,6 @@ SECTIONS
         _ebss = .;         /* define a global symbol at bss end; used by startup code and GC */
     } >RAM
 
-    /* this is to define the start of the heap, and make sure we have a minimum size */
-    .heap :
-    {
-        . = ALIGN(4);
-	PROVIDE ( end = . );
-	PROVIDE ( _end = . );
-        _heap_start = .;    /* define a global symbol at heap start */
-        . = . + _minimum_heap_size;
-    } >RAM
-
-    /* this just checks there is enough RAM for the stack */
-    .stack :
-    {
-        . = ALIGN(4);
-        . = . + _stack_size;
-        . = ALIGN(4);
-    } >RAM
-
     /* Remove information from the standard libraries */
     /*
     /DISCARD/ :
@@ -97,4 +79,3 @@ SECTIONS
 /* Define heap and stack areas */
 _ram_end = ORIGIN(RAM) + LENGTH(RAM);
 _estack = ORIGIN(RAM) + LENGTH(RAM);
-_heap_end = _ram_end - _stack_size;

--- a/ports/nrf/boards/memory.ld
+++ b/ports/nrf/boards/memory.ld
@@ -10,6 +10,11 @@ _fs_start      = _sd_size + _app_size;
 _fs_end        = _fs_start + _fs_size;
 _app_ram_start = 0x20000000 + _sd_ram;
 _app_ram_size  = _ram_size - _sd_ram;
+_heap_start    = _ebss;
+_heap_end      = _ram_end - _stack_size;
+_heap_size     = _heap_end - _heap_start;
+
+ASSERT(_heap_size >= _minimum_heap_size, "not enough RAM left for heap")
 
 /* Specify the memory areas */
 MEMORY


### PR DESCRIPTION
The main effect of this is that the .bss as reported by `arm-none-eabi-size` is now accurate and doesn't include the stack and minimum heap size. Also, the error message may be clearer.