### PR TITLE
nrf: Quick-fixes on const objects that have open array dimension in o…

### DIFF
--- a/ports/nrf/boards/microbit/modules/microbitconstimage.h
+++ b/ports/nrf/boards/microbit/modules/microbitconstimage.h
@@ -27,7 +27,20 @@
 #ifndef __MICROPY_INCLUDED_MICROBIT_CONSTIMAGE_H__
 #define __MICROPY_INCLUDED_MICROBIT_CONSTIMAGE_H__
 
+typedef struct _image_tuple_12 {
+    mp_obj_base_t base;
+    size_t len;
+    mp_rom_obj_t items[12];
+} image_tuple_12_t;
 
+typedef struct _image_tuple_8 {
+    mp_obj_base_t base;
+    size_t len;
+    mp_rom_obj_t items[8];
+} image_tuple_8_t;
+
+extern const image_tuple_12_t microbit_const_image_all_clocks_tuple_obj;
+extern const image_tuple_8_t microbit_const_image_all_arrows_tuple_obj;
 extern const mp_obj_type_t microbit_const_image_type;
 extern const struct _monochrome_5by5_t microbit_const_image_heart_obj;
 extern const struct _monochrome_5by5_t microbit_const_image_heart_small_obj;
@@ -79,8 +92,6 @@ extern const struct _monochrome_5by5_t microbit_const_image_pitchfork_obj;
 extern const struct _monochrome_5by5_t microbit_const_image_xmas_obj;
 extern const struct _monochrome_5by5_t microbit_const_image_pacman_obj;
 extern const struct _monochrome_5by5_t microbit_const_image_target_obj;
-extern const struct _mp_obj_tuple_t microbit_const_image_all_clocks_tuple_obj;
-extern const struct _mp_obj_tuple_t microbit_const_image_all_arrows_tuple_obj;
 extern const struct _monochrome_5by5_t microbit_const_image_tshirt_obj;
 extern const struct _monochrome_5by5_t microbit_const_image_rollerskate_obj;
 extern const struct _monochrome_5by5_t microbit_const_image_duck_obj;

--- a/ports/nrf/boards/microbit/modules/microbitconstimagetuples.c
+++ b/ports/nrf/boards/microbit/modules/microbitconstimagetuples.c
@@ -25,7 +25,7 @@
 #include "py/runtime.h"
 #include "microbitconstimage.h"
 
-const mp_obj_tuple_t microbit_const_image_all_clocks_tuple_obj = {
+const image_tuple_12_t microbit_const_image_all_clocks_tuple_obj = {
     {&mp_type_tuple},
     .len = 12,
     .items = {
@@ -44,7 +44,7 @@ const mp_obj_tuple_t microbit_const_image_all_clocks_tuple_obj = {
     }
 };
 
-const mp_obj_tuple_t microbit_const_image_all_arrows_tuple_obj = {
+const image_tuple_8_t microbit_const_image_all_arrows_tuple_obj = {
     {&mp_type_tuple},
     .len = 8,
     .items = {

--- a/ports/nrf/modules/music/musictunes.c
+++ b/ports/nrf/modules/music/musictunes.c
@@ -35,7 +35,14 @@
 #if MICROPY_PY_MUSIC
 
 #define N(q) MP_ROM_QSTR(MP_QSTR_ ## q)
-#define T(name, ...) const mp_obj_tuple_t microbit_music_tune_ ## name ## _obj = {{&mp_type_tuple}, .len = (sizeof((mp_obj_t[]){__VA_ARGS__})/sizeof(mp_obj_t)), .items = {__VA_ARGS__}};
+#define T(name, ...) \
+typedef struct music_tune_ ## name ## _s {\
+    mp_obj_base_t base; \
+    size_t len; \
+    mp_rom_obj_t items[sizeof((mp_obj_t[]){__VA_ARGS__})/sizeof(mp_obj_t)]; \
+} music_tune_ ## name ## _t; \
+\
+const music_tune_ ## name ## _t microbit_music_tune_ ## name ## _obj = {{&mp_type_tuple}, .len = (sizeof((mp_obj_t[]){__VA_ARGS__})/sizeof(mp_obj_t)), .items = {__VA_ARGS__}};
 
 
 T(dadadadum,

--- a/ports/nrf/modules/music/musictunes.h
+++ b/ports/nrf/modules/music/musictunes.h
@@ -27,26 +27,48 @@
 #ifndef MUSIC_TUNES_H__
 #define MUSIC_TUNES_H__
 
-extern const struct _mp_obj_tuple_t microbit_music_tune_dadadadum_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_entertainer_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_prelude_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_ode_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_nyan_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_ringtone_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_funk_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_blues_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_birthday_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_wedding_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_funeral_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_punchline_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_python_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_baddy_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_chase_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_ba_ding_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_wawawawaa_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_jump_up_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_jump_down_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_power_up_obj;
-extern const struct _mp_obj_tuple_t microbit_music_tune_power_down_obj;
+struct music_tune_dadadum_s;
+struct music_tune_entertainer_s;
+struct music_tune_prelude_s;
+struct music_tune_ode_s;
+struct music_tune_nyan_s;
+struct music_tune_ringtone_s;
+struct music_tune_funk_s;
+struct music_tune_blues_s;
+struct music_tune_birthday_s;
+struct music_tune_wedding_s;
+struct music_tune_funeral_s;
+struct music_tune_punchline_s;
+struct music_tune_python_s;
+struct music_tune_baddy_s;
+struct music_tune_chase_s;
+struct music_tune_ba_ding_s;
+struct music_tune_wawawawaa_s;
+struct music_tune_jump_up_s;
+struct music_tune_jump_down_s;
+struct music_tune_power_up_s;
+struct music_tune_power_down_s;
+
+extern const struct music_tune_dadadadum_s   microbit_music_tune_dadadadum_obj;
+extern const struct music_tune_entertainer_s microbit_music_tune_entertainer_obj;
+extern const struct music_tune_prelude_s     microbit_music_tune_prelude_obj;
+extern const struct music_tune_ode_s         microbit_music_tune_ode_obj;
+extern const struct music_tune_nyan_s        microbit_music_tune_nyan_obj;
+extern const struct music_tune_ringtone_s    microbit_music_tune_ringtone_obj;
+extern const struct music_tune_funk_s        microbit_music_tune_funk_obj;
+extern const struct music_tune_blues_s       microbit_music_tune_blues_obj;
+extern const struct music_tune_birthday_s    microbit_music_tune_birthday_obj;
+extern const struct music_tune_wedding_s     microbit_music_tune_wedding_obj;
+extern const struct music_tune_funeral_s     microbit_music_tune_funeral_obj;
+extern const struct music_tune_punchline_s   microbit_music_tune_punchline_obj;
+extern const struct music_tune_python_s      microbit_music_tune_python_obj;
+extern const struct music_tune_baddy_s       microbit_music_tune_baddy_obj;
+extern const struct music_tune_chase_s       microbit_music_tune_chase_obj;
+extern const struct music_tune_ba_ding_s     microbit_music_tune_ba_ding_obj;
+extern const struct music_tune_wawawawaa_s   microbit_music_tune_wawawawaa_obj;
+extern const struct music_tune_jump_up_s     microbit_music_tune_jump_up_obj;
+extern const struct music_tune_jump_down_s   microbit_music_tune_jump_down_obj;
+extern const struct music_tune_power_up_s    microbit_music_tune_power_up_obj;
+extern const struct music_tune_power_down_s  microbit_music_tune_power_down_obj;
 
 #endif // MUSIC_TUNES_H__


### PR DESCRIPTION
…bjtuples

Temporarly solving the issue of
"differ from the size of original declaration [-Werror=lto-type-mismatch]
until linker is fixed in upcomming release of gcc.

Bug is reported by others, and will be fixed in next version of arm-gcc.
However, this patch makes it possible to use modmusic and modimage
with current compilers.

Alternativly, the code can be compiled with LTO=0, but uses valuable 9K
more on this already squeezed target (microbit).