### PR TITLE
nrf: Add explicit make flag for oofatfs

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -41,7 +41,7 @@ QSTR_DEFS = qstrdefsport.h $(BUILD)/pins_qstr.h
 # include py core make definitions
 include ../../py/py.mk
 
-
+MICROPY_FATFS ?= 0
 FATFS_DIR = lib/oofatfs
 MPY_CROSS = ../../mpy-cross/mpy-cross
 MPY_TOOL = ../../tools/mpy-tool.py
@@ -158,9 +158,15 @@ SRC_LIB += $(addprefix lib/,\
 	utils/pyexec.c \
 	utils/interrupt_char.c \
 	timeutils/timeutils.c \
-	oofatfs/ff.c \
-	oofatfs/option/unicode.c \
 	)
+
+ifeq ($(MICROPY_FATFS), 1)
+SRC_LIB += $(addprefix lib/,\
+        oofatfs/ff.c \
+        oofatfs/option/unicode.c \
+        )
+endif
+
 
 SRC_NRFX += $(addprefix lib/nrfx/drivers/src/,\
 	prs/nrfx_prs.c \

--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -86,6 +86,13 @@ To use frozen modules, put them in a directory (e.g. `freeze/`) and supply
 
      make BOARD=pca10040 FROZEN_MPY_DIR=freeze
 
+## Enable MICROPY_FATFS
+As the `oofatfs` module is not having header guards that can exclude the implementation compile time, this port provides a flag to enable it explicitly. The MICROPY_FATFS is by default set to 0 and has to be set to 1 if `oofatfs` files should be compiled. This will be in addition of setting `MICROPY_VFS` and `MICROPY_VFS_FAT` in mpconfigport.h.
+
+For example:
+
+     make BOARD=pca10040 MICROPY_FATFS=1
+
 ## Target Boards and Make Flags
 
 Target Board (BOARD) | Bluetooth Stack (SD)    | Bluetooth Support      | Flash Util


### PR DESCRIPTION
Adding MICROPY_FATFS as makefile flag in order to explicitly
include oofatfs files to be compiled into the build.

The flag is set to 0 by default. Must be set in addition to
MICROPY_VFS and MICROPY_VFS_FAT in mpconfigport.h.