### PR TITLE
nrf/bluetooth: Replace BLE REPL (WebBluetooth) URL

### DIFF
--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -132,9 +132,9 @@ The configuration can be enabled by editing the `bluetooth_conf.h` and set `MICR
 
 When enabled you have different options to test it:
 * [NUS Console for Linux](https://github.com/tralamazza/nus_console) (recommended)
-* [WebBluetooth REPL](https://glennrub.github.io/webbluetooth/micropython/repl/) (experimental)
+* [WebBluetooth REPL](https://aykevl.nl/apps/nus/) (experimental)
 
 Other:
 * nRF UART application for IPhone/Android
 
-WebBluetooth mode can also be configured by editing `bluetooth_conf.h` and set `BLUETOOTH_WEBBLUETOOTH_REPL` to 1. This will alternate advertisement between Eddystone URL and regular connectable advertisement. The Eddystone URL will point the phone or PC to download [WebBluetooth REPL](https://glennrub.github.io/webbluetooth/micropython/repl/) (experimental), which subsequently can be used to connect to the Bluetooth REPL from the PC or Phone browser.
+WebBluetooth mode can also be configured by editing `bluetooth_conf.h` and set `BLUETOOTH_WEBBLUETOOTH_REPL` to 1. This will alternate advertisement between Eddystone URL and regular connectable advertisement. The Eddystone URL will point the phone or PC to download [WebBluetooth REPL](https://aykevl.nl/apps/nus/) (experimental), which subsequently can be used to connect to the Bluetooth REPL from the PC or Phone browser.

--- a/ports/nrf/drivers/bluetooth/ble_uart.c
+++ b/ports/nrf/drivers/bluetooth/ble_uart.c
@@ -229,10 +229,10 @@ void ble_uart_init0(void) {
     m_adv_data_uart_service.p_data          = NULL;
 
 #if BLUETOOTH_WEBBLUETOOTH_REPL
-    // for now point eddystone URL to https://goo.gl/x46FES => https://glennrub.github.io/webbluetooth/micropython/repl/
+    // for now point eddystone URL to https://goo.gl/F7fZ69 => https://aykevl.nl/apps/nus/
     static uint8_t eddystone_url_data[27] = {0x2, 0x1, 0x6,
                                              0x3, 0x3, 0xaa, 0xfe,
-                                             19, 0x16, 0xaa, 0xfe, 0x10, 0xee, 0x3, 'g', 'o', 'o', '.', 'g', 'l', '/', 'x', '4', '6', 'F', 'E', 'S'};
+                                             19, 0x16, 0xaa, 0xfe, 0x10, 0xee, 0x3, 'g', 'o', 'o', '.', 'g', 'l', '/', 'F', '7', 'f', 'Z', '6', '9'};
     // eddystone url adv data
     m_adv_data_eddystone_url.p_data      = eddystone_url_data;
     m_adv_data_eddystone_url.data_len    = sizeof(eddystone_url_data);


### PR DESCRIPTION
Updating URL of the WebBluetooth/PhysicalWeb from
https://glennrub.github.io/webbluetooth/micropython/repl to
https://aykevl.nl/apps/nus/.