### PR TITLE
nrf: Compile nlr objects with -fno-lto flag

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -348,5 +348,7 @@ CFLAGS += -DMICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool
 CFLAGS += -DMICROPY_MODULE_FROZEN_MPY
 endif
 
+$(PY_BUILD)/nlr%.o: CFLAGS += -Os -fno-lto
+
 include ../../py/mkrules.mk
 


### PR DESCRIPTION
To prevent over-optimizations of nlr and nlrthumb when -flto is used
the flag -fno-lto is set on these modules during compilation.